### PR TITLE
Add module to do sentinel and mcas integration

### DIFF
--- a/soc-integration/main.tf
+++ b/soc-integration/main.tf
@@ -1,0 +1,8 @@
+variable "config" {
+  type    = map(string)
+  default = {}
+}
+
+provider "aws" {
+  alias = "member"
+}

--- a/soc-integration/mcas.tf
+++ b/soc-integration/mcas.tf
@@ -1,0 +1,61 @@
+// configuration as per: https://docs.microsoft.com/en-us/cloud-app-security/connect-aws-to-microsoft-cloud-app-security
+
+resource "aws_iam_access_key" "access_key" {
+  provider = aws.member
+  user    = aws_iam_user.user.name
+}
+
+resource "aws_iam_user" "user" {
+  provider = aws.member
+  name = "CloudAppSecurityAWS"
+  path = "/"
+}
+
+resource "aws_iam_user_policy" "policy" {
+  provider = aws.member
+  name = "CloudAppSecurityPolicy"
+  user = aws_iam_user.user.name
+
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [{
+        "Action" : [
+          "cloudtrail:DescribeTrails",
+          "cloudtrail:LookupEvents",
+          "cloudtrail:GetTrailStatus",
+          "cloudwatch:Describe*",
+          "cloudwatch:Get*",
+          "cloudwatch:List*",
+          "iam:List*",
+          "iam:Get*",
+          "s3:ListAllMyBuckets",
+          "s3:PutBucketAcl",
+          "s3:GetBucketAcl",
+          "s3:GetBucketLocation"
+        ],
+        "Effect" : "Allow",
+        "Resource" : "*"
+      }
+    ]
+   })
+}
+
+resource "aws_iam_user_policy_attachment" "security-hub-policy" {
+  provider = aws.member
+  user       = aws_iam_user.user.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSSecurityHubReadOnlyAccess"
+}
+
+resource "aws_iam_user_policy_attachment" "security-audit-policy" {
+  provider = aws.member
+  user       = aws_iam_user.user.name
+  policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
+}
+
+output "mcas_access_key_id" {
+  value = aws_iam_access_key.access_key.id
+}
+
+output "mcas_access_key_secret" {
+  value = aws_iam_access_key.access_key.secret
+}

--- a/soc-integration/sentinel.tf
+++ b/soc-integration/sentinel.tf
@@ -1,0 +1,34 @@
+// configuration as per: https://docs.microsoft.com/en-us/azure/sentinel/connect-aws
+
+resource "aws_iam_role" "azure_sentinel" {
+  provider = aws.member
+  name = "AzureSentinelRole"
+
+  assume_role_policy = jsonencode({
+  Version = "2012-10-17"
+  Statement = [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${var.config["sentinel_account_id"]}:root"
+    },
+    "Action": "sts:AssumeRole",
+    "Condition": {
+      "StringEquals": {
+        "sts:ExternalId": "${var.config["sentinel_workspace_id"]}"
+      }
+    }
+  }
+  ]
+})
+}
+
+resource "aws_iam_role_policy_attachment" "cloudtrail_readonly" {
+  provider = aws.member
+  role = aws_iam_role.azure_sentinel.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSCloudTrailReadOnlyAccess"
+}
+
+output "azure-sentinel-role-arn" {
+  value = aws_iam_role.azure_sentinel.arn
+}


### PR DESCRIPTION
This creates a federated role for cloudtrail integration and an IAM user with cloudtrail, aws config and aws security hub permissions.