### PR TITLE
Update deprecated types

### DIFF
--- a/new-org-member/output.tf
+++ b/new-org-member/output.tf
@@ -8,10 +8,10 @@ data "null_data_source" "org_member" {
 }
 
 output "org_master" {
-  value = map(
-            "account_id", aws_organizations_account.member.id,
-            "account_arn", aws_organizations_account.member.arn,
-            "account_email", var.member["email"],
-            "account_alias", var.member["name"]
-          )
+  value = tomap({
+            "account_id" = aws_organizations_account.member.id,
+            "account_arn" = aws_organizations_account.member.arn,
+            "account_email" = var.member["email"],
+            "account_alias" = var.member["name"]
+          })
 }

--- a/org-master/cloudtrail.tf
+++ b/org-master/cloudtrail.tf
@@ -42,14 +42,11 @@ resource "aws_iam_role_policy" "cloudtrail_log_policy" {
   provider = aws.master
   name = "cloudtrail_log"
   role = aws_iam_role.cloudtrail_log.id
-  policy = data.template_file.cloudtrail-policy.rendered
-}
-
-data "template_file" "cloudtrail-policy" {
-  template = file("${path.module}/policies/cloudtrail-role.json")
-  vars = {
-    cloudtrail_log_stream = aws_cloudwatch_log_group.cloudtrail.arn
-  }
+  policy = templatefile("${path.module}/policies/cloudtrail-role.json",
+    {
+      cloudtrail_log_stream = aws_cloudwatch_log_group.cloudtrail.arn
+    }
+  )
 }
 
 resource "aws_s3_bucket" "cloudtrail-s3" {
@@ -66,25 +63,19 @@ resource "aws_s3_bucket" "cloudtrail-s3" {
   tags = {
     "website" = "false"
   }
-  policy = data.template_file.cloudtrail-s3.rendered
-}
-
-data "template_file" "cloudtrail-s3" {
-  template = file("${path.module}/policies/cloudtrail-s3.json")
-  vars = {
-    cloudtrail_s3 = "cloudtrail-${data.aws_caller_identity.master.account_id}"
-  }
+  policy = templatefile("${path.module}/policies/cloudtrail-s3.json",
+    {
+      cloudtrail_s3 = "cloudtrail-${data.aws_caller_identity.master.account_id}"
+    }
+  )
 }
 
 resource "aws_kms_key" "cloudtrail-kms" {
   provider = aws.master
   description = "CloudTrail KMS Key"
-  policy = data.template_file.cloudtrail-kms.rendered
-}
-
-data "template_file" "cloudtrail-kms" {
-  template = file("${path.module}/policies/cloudtrail-kms.json")
-  vars = {
-    aws_account_id = data.aws_caller_identity.master.account_id
-  }
+  policy = templatefile("${path.module}/policies/cloudtrail-kms.json",
+    {
+      aws_account_id = data.aws_caller_identity.master.account_id
+    }
+  )
 }

--- a/org-master/cloudwatch.tf
+++ b/org-master/cloudwatch.tf
@@ -9,13 +9,10 @@ resource "aws_cloudwatch_log_group" "master" {
 resource "aws_kms_key" "cloudwatch" {
   provider = aws.master
   description = "CloudWatch Key"
-  policy = data.template_file.cloudwatch-kms-policy.rendered
-}
-
-data "template_file" "cloudwatch-kms-policy" {
-  template = file("${path.module}/policies/cloudwatch-kms.json")
-  vars = {
-    aws_account_id = data.aws_caller_identity.master.account_id
-    aws_region = data.aws_region.master.name
-  }
+  policy = templatefile("${path.module}/policies/cloudwatch-kms.json",
+    {
+      aws_account_id = data.aws_caller_identity.master.account_id,
+      aws_region = data.aws_region.master.name
+    }
+  )
 }

--- a/org-master/config.tf
+++ b/org-master/config.tf
@@ -76,18 +76,15 @@ resource "aws_s3_bucket" "master_config_bucket" {
   }
 }
 
-data "template_file" "config_s3_policy" {
-  template = file("${path.module}/policies/config-s3.json")
-  vars = {
-    config_s3_arn = aws_s3_bucket.master_config_bucket.arn
-  }
-}
-
 resource "aws_iam_role_policy" "config_s3_policy" {
   provider = aws.master
   name = "config_s3_policy"
   role = aws_iam_role.master_config_role.name
-  policy = data.template_file.config_s3_policy.rendered
+  policy = templatefile("${path.module}/policies/config-s3.json",
+    {
+      config_s3_arn = aws_s3_bucket.master_config_bucket.arn
+    }
+  )
 }
 
 resource "aws_config_configuration_recorder_status" "master_config" {

--- a/org-master/output.tf
+++ b/org-master/output.tf
@@ -16,18 +16,18 @@ data "null_data_source" "org_master" {
 }
 
 output "org_master" {
-  value = map(
-            "aws_shared_credentials_file", var.org["aws_shared_credentials_file"],
-            "aws_profile", var.org["aws_profile"],
-            "organization_arn", aws_organizations_organization.org.arn,
-            "organization_id", aws_organizations_organization.org.id,
-            "cloudtrail_arn", aws_cloudtrail.trail.arn,
-            "cloudwatch_eventbus_arn", "arn:aws:events:${data.aws_region.master.name}:${data.aws_caller_identity.master.account_id}:event-bus/default",
-            "config_id", aws_config_configuration_recorder.master_config.id,
-            "config_sns_arn", aws_sns_topic.config_sns.arn,
-            "config_role_arn", aws_iam_role.master_config_role.arn,
-            "config_role_name", aws_iam_role.master_config_role.name,
-            "guardduty_id", aws_guardduty_detector.master.id,
-            "bastion_account", var.org["bastion_account"]
-          )
+  value = tomap({
+            "aws_shared_credentials_file" = var.org["aws_shared_credentials_file"],
+            "aws_profile" = var.org["aws_profile"],
+            "organization_arn" = aws_organizations_organization.org.arn,
+            "organization_id" = aws_organizations_organization.org.id,
+            "cloudtrail_arn" = aws_cloudtrail.trail.arn,
+            "cloudwatch_eventbus_arn" = "arn:aws:events:${data.aws_region.master.name}:${data.aws_caller_identity.master.account_id}:event-bus/default",
+            "config_id" = aws_config_configuration_recorder.master_config.id,
+            "config_sns_arn" = aws_sns_topic.config_sns.arn,
+            "config_role_arn" = aws_iam_role.master_config_role.arn,
+            "config_role_name" = aws_iam_role.master_config_role.name,
+            "guardduty_id"=  aws_guardduty_detector.master.id,
+            "bastion_account" = var.org["bastion_account"]
+          })
 }

--- a/org-member/cloudtrail.tf
+++ b/org-member/cloudtrail.tf
@@ -41,14 +41,11 @@ resource "aws_iam_role_policy" "cloudtrail_log_policy" {
   provider = aws.member
   name = "cloudtrail_log"
   role = aws_iam_role.cloudtrail_log.id
-  policy = data.template_file.cloudtrail-policy.rendered
-}
-
-data "template_file" "cloudtrail-policy" {
-  template = file("${path.module}/policies/cloudtrail-role.json")
-  vars = {
-    cloudtrail_log_stream = aws_cloudwatch_log_group.cloudtrail.arn
-  }
+  policy = templatefile("${path.module}/policies/cloudtrail-role.json",
+    {
+      cloudtrail_log_stream = aws_cloudwatch_log_group.cloudtrail.arn
+    }
+  )
 }
 
 resource "aws_s3_bucket" "cloudtrail-s3" {
@@ -65,25 +62,19 @@ resource "aws_s3_bucket" "cloudtrail-s3" {
   tags = {
     "website" = "false"
   }
-  policy = data.template_file.cloudtrail-s3.rendered
-}
-
-data "template_file" "cloudtrail-s3" {
-  template = file("${path.module}/policies/cloudtrail-s3.json")
-  vars = {
-    cloudtrail_s3 = "cloudtrail-${data.aws_caller_identity.member.account_id}"
-  }
+  policy = templatefile("${path.module}/policies/cloudtrail-s3.json",
+    {
+      cloudtrail_s3 = "cloudtrail-${data.aws_caller_identity.member.account_id}"
+    }
+  )
 }
 
 resource "aws_kms_key" "cloudtrail-kms" {
   provider = aws.member
   description = "CloudTrail KMS Key"
-  policy = data.template_file.cloudtrail-kms.rendered
-}
-
-data "template_file" "cloudtrail-kms" {
-  template = file("${path.module}/policies/cloudtrail-kms.json")
-  vars = {
-    aws_account_id = data.aws_caller_identity.member.account_id
-  }
+  policy = templatefile("${path.module}/policies/cloudtrail-kms.json",
+    {
+      aws_account_id = data.aws_caller_identity.member.account_id
+    }
+  )
 }

--- a/org-member/config.tf
+++ b/org-member/config.tf
@@ -39,18 +39,15 @@ resource "aws_s3_bucket" "config_bucket" {
   }
 }
 
-data "template_file" "config_s3_policy" {
-  template = file("${path.module}/policies/config-s3.json")
-  vars = {
-    config_s3_arn = aws_s3_bucket.config_bucket.arn
-  }
-}
-
 resource "aws_iam_role_policy" "config_s3_policy" {
   provider = aws.member
   name = "config_s3_policy"
   role = aws_iam_role.config_role.name
-  policy = data.template_file.config_s3_policy.rendered
+  policy = templatefile("${path.module}/policies/config-s3.json",
+    {
+      config_s3_arn = aws_s3_bucket.config_bucket.arn
+    }
+  )
 }
 
 resource "aws_config_configuration_recorder" "config" {

--- a/soc-integration/sentinel.tf
+++ b/soc-integration/sentinel.tf
@@ -15,7 +15,7 @@ resource "aws_iam_role" "azure_sentinel" {
     "Action": "sts:AssumeRole",
     "Condition": {
       "StringEquals": {
-        "sts:ExternalId": "${var.config["sentinel_workspace_id"]}"
+        "sts:ExternalId": var.config["sentinel_workspace_id"]
       }
     }
   }


### PR DESCRIPTION
Makes the following updates:
- Replaces all `map` functions with `tomap`
- Replaces all `template_file` resources with a `templatefile` function.
- Removes an interpolation-only expression.

References:
- "The map function is no longer available..." https://www.terraform.io/language/functions/map
- "The Template provider has been archived..." https://registry.terraform.io/providers/hashicorp/template
- "Interpolation-only expressions are deprecated..." https://www.hashicorp.com/blog/terraform-0-1-2-preview