### PR TITLE
Configure Sentinel S3 Connector AWS Resources

### DIFF
--- a/org-master/guardduty.tf
+++ b/org-master/guardduty.tf
@@ -118,3 +118,13 @@ resource "aws_cloudwatch_event_rule" "guardduty" {
     }
 INPUT
 }
+
+resource "aws_guardduty_publishing_destination" "master" {
+  provider = aws.master
+  detector_id = aws_guardduty_detector.master.id
+  destination_arn = "${aws_s3_bucket.sentinel_logs.arn}/${local.sentinel_guardduty_folder}"
+  kms_key_arn = aws_kms_key.sentinel_guard_duty.arn
+  depends_on = [
+    aws_s3_bucket_policy.sentinel_logs
+  ]
+}

--- a/org-master/guardduty.tf
+++ b/org-master/guardduty.tf
@@ -2,6 +2,7 @@
 resource "aws_guardduty_detector" "master" {
   provider = aws.master
   enable = true
+  finding_publishing_frequency = "FIFTEEN_MINUTES"
 }
 
 resource "aws_sns_topic" "guardduty_sns" {

--- a/org-master/kms.tf
+++ b/org-master/kms.tf
@@ -1,0 +1,18 @@
+resource "aws_kms_key" "sentinel_guard_duty" {
+  description = "Sentinel GuardDuty KMS Key"
+  policy = templatefile("${path.module}/policies/guardduty-kms.json",
+    {
+      master_account_id = data.aws_caller_identity.master.account_id
+      sentinel_role_arn = aws_iam_role.sentinel_role.arn
+    }
+  )
+  tags = {
+    Operator = "Microsoft_Sentinel_Automation_Script"
+  }
+}
+
+resource "aws_kms_alias" "sentinel_guard_duty" {
+  name = "alias/sentinel-guardduty-key"
+  target_key_id = aws_kms_key.sentinel_guard_duty.key_id
+}
+

--- a/org-master/local.tf
+++ b/org-master/local.tf
@@ -1,0 +1,4 @@
+locals {
+  sentinel_vpc_flow_log_folder = "VPC-Flow-Log"
+  sentinel_guardduty_folder = "GuardDuty"
+}

--- a/org-master/main.tf
+++ b/org-master/main.tf
@@ -6,6 +6,11 @@ variable "org" {
   }
 }
 
+variable "config" {
+  type    = map(string)
+  default = {}
+}
+
 provider "aws" {
   alias = "master"
 }

--- a/org-master/output.tf
+++ b/org-master/output.tf
@@ -12,6 +12,7 @@ data "null_data_source" "org_master" {
     config_role_arn = aws_iam_role.master_config_role.arn
     config_role_name = aws_iam_role.master_config_role.name
     guardduty_id = aws_guardduty_detector.master.id
+    sentinel_vpc_s3_bucket = "${aws_s3_bucket.sentinel_logs.arn}/${local.sentinel_vpc_flow_log_folder}"
     bastion_account = var.org["bastion_account"]
   }
 }
@@ -30,6 +31,7 @@ output "org_master" {
             "config_role_arn" = aws_iam_role.master_config_role.arn,
             "config_role_name" = aws_iam_role.master_config_role.name,
             "guardduty_id"=  aws_guardduty_detector.master.id,
+            sentinel_vpc_s3_bucket = "${aws_s3_bucket.sentinel_logs.arn}/${local.sentinel_vpc_flow_log_folder}"
             "bastion_account" = var.org["bastion_account"]
           })
 }

--- a/org-master/output.tf
+++ b/org-master/output.tf
@@ -1,5 +1,6 @@
 data "null_data_source" "org_master" {
   inputs = {
+    account_id = data.aws_caller_identity.master.account_id
     aws_shared_credentials_file = var.org["aws_shared_credentials_file"]
     aws_profile = var.org["aws_profile"]
     organization_arn = aws_organizations_organization.org.arn
@@ -17,6 +18,7 @@ data "null_data_source" "org_master" {
 
 output "org_master" {
   value = tomap({
+            "account_id" = data.aws_caller_identity.master.account_id
             "aws_shared_credentials_file" = var.org["aws_shared_credentials_file"],
             "aws_profile" = var.org["aws_profile"],
             "organization_arn" = aws_organizations_organization.org.arn,

--- a/org-master/policies/guardduty-kms.json
+++ b/org-master/policies/guardduty-kms.json
@@ -1,0 +1,38 @@
+{
+  "Version": "2008-10-17",
+  "Statement": [
+        {
+            "Sid": "Enable IAM User Permissions",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::${master_account_id}:root"
+            },
+            "Action": "kms:*",
+            "Resource": "*"
+        },
+        {
+            "Sid": "Allow GuardDuty to use the key",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "guardduty.amazonaws.com"
+            },
+            "Action": "kms:GenerateDataKey",
+            "Resource": "*"
+        },
+        {
+            "Sid": "Allow Sentinel to use the key",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "${sentinel_role_arn}"
+            },
+            "Action": [
+                "kms:Encrypt",
+                "kms:Decrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+                "kms:DescribeKey"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/org-master/policies/guardduty-kms.json
+++ b/org-master/policies/guardduty-kms.json
@@ -20,6 +20,21 @@
             "Resource": "*"
         },
         {
+            "Sid": "Allow VPC Flow Logs to use the key",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "delivery.logs.amazonaws.com"
+            },
+           "Action": [
+               "kms:Encrypt",
+               "kms:Decrypt",
+               "kms:ReEncrypt*",
+               "kms:GenerateDataKey*",
+               "kms:DescribeKey"
+            ],
+            "Resource": "*"
+        },
+        {
             "Sid": "Allow Sentinel to use the key",
             "Effect": "Allow",
             "Principal": {

--- a/org-master/policies/s3-sqs.json
+++ b/org-master/policies/s3-sqs.json
@@ -1,0 +1,35 @@
+{
+    "Version": "2012-10-17",
+    "Id": "sqspolicy",
+    "Statement": [
+      {
+        "Sid": "allow s3 to send notification messages to SQS queue",
+        "Effect": "Allow",
+        "Principal": {
+            "Service": "s3.amazonaws.com"
+            },
+        "Action": "SQS:SendMessage",
+        "Resource": "${aws_sqs_queue_arn}",
+        "Condition": {
+          "ArnLike": {
+            "aws:SourceArn": "${aws_s3_bucket_arn}"
+          }
+        }
+      },
+      {
+          "Sid": "allow specific role to read/delete/change visibility of SQS messages and get queue url",
+          "Effect": "Allow",
+          "Principal": {
+              "AWS": "${aws_iam_role_arn}"
+              },
+          "Action": [
+              "SQS:ChangeMessageVisibility",
+              "SQS:DeleteMessage",
+              "SQS:ReceiveMessage",
+              "SQS:GetQueueUrl"
+          ],
+          "Resource": "${aws_sqs_queue_arn}"
+      }
+    ]
+  }
+  

--- a/org-master/s3.tf
+++ b/org-master/s3.tf
@@ -106,15 +106,27 @@ resource "aws_s3_bucket_notification" "sentinel_logs" {
   queue {
     queue_arn     = aws_sqs_queue.sentinel_flowlog_queue.arn
     events        = ["s3:ObjectCreated:*"]
-    filter_prefix = "VPC-Flow-Log/" 
+    filter_prefix = aws_s3_bucket_object.sentinel_vpc_flow_log_folder.id
     filter_suffix = ".gz"
   }
 
   queue {
     queue_arn     = aws_sqs_queue.sentinel_guardduty_queue.arn
     events        = ["s3:ObjectCreated:*"]
-    filter_prefix = "GuardDuty/"
+    filter_prefix = aws_s3_bucket_object.sentinel_guardduty_folder.id
     filter_suffix = ".gz"
   }
 
+}
+
+resource "aws_s3_bucket_object" "sentinel_vpc_flow_log_folder" {
+    bucket = aws_s3_bucket.sentinel_logs.id
+    content_type = "application/x-directory"
+    key = "${local.sentinel_vpc_flow_log_folder}/"
+}
+
+resource "aws_s3_bucket_object" "sentinel_guardduty_folder" {
+    bucket = aws_s3_bucket.sentinel_logs.id
+    content_type = "application/x-directory"
+    key = "${local.sentinel_guardduty_folder}/"
 }

--- a/org-master/s3.tf
+++ b/org-master/s3.tf
@@ -98,3 +98,23 @@ data "aws_iam_policy_document" "sentinel_logs" {
   }
   
 }
+
+resource "aws_s3_bucket_notification" "sentinel_logs" {
+  provider = aws.master
+  bucket   = aws_s3_bucket.sentinel_logs.id
+
+  queue {
+    queue_arn     = aws_sqs_queue.sentinel_flowlog_queue.arn
+    events        = ["s3:ObjectCreated:*"]
+    filter_prefix = "VPC-Flow-Log/" 
+    filter_suffix = ".gz"
+  }
+
+  queue {
+    queue_arn     = aws_sqs_queue.sentinel_guardduty_queue.arn
+    events        = ["s3:ObjectCreated:*"]
+    filter_prefix = "GuardDuty/"
+    filter_suffix = ".gz"
+  }
+
+}

--- a/org-master/s3.tf
+++ b/org-master/s3.tf
@@ -97,6 +97,28 @@ data "aws_iam_policy_document" "sentinel_logs" {
     }
   }
   
+  statement {
+    sid = "AWSLogDeliveryWrite"
+    actions = ["s3:PutObject"]
+    effect = "Allow"
+    resources = ["${aws_s3_bucket.sentinel_logs.arn}/*"]
+    principals {
+        type = "Service"
+        identifiers = ["delivery.logs.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid = "AWSLogDeliveryCheck"
+    actions = ["s3:GetBucketAcl", "s3:ListBucket"]
+    effect = "Allow"
+    resources = ["${aws_s3_bucket.sentinel_logs.arn}"]
+    principals {
+        type = "Service"
+        identifiers = ["delivery.logs.amazonaws.com"]
+    }
+  }
+
 }
 
 resource "aws_s3_bucket_notification" "sentinel_logs" {

--- a/org-master/s3.tf
+++ b/org-master/s3.tf
@@ -1,0 +1,100 @@
+resource "aws_s3_bucket" "sentinel_logs" {
+  provider = aws.master
+  bucket   = "sentinel-logs-${data.aws_caller_identity.master.account_id}"
+  acl      = "private"
+  tags     = {
+    Operator = "Microsoft_Sentinel_Automation_Script"
+  }
+}
+
+resource "aws_s3_bucket_policy" "sentinel_logs" {
+  provider = aws.master
+  bucket   = aws_s3_bucket.sentinel_logs.id
+  policy   = data.aws_iam_policy_document.sentinel_logs.json
+}
+
+data "aws_iam_policy_document" "sentinel_logs" {
+  provider = aws.master
+
+  statement {
+    sid = "Allow Sentinel role read access to S3 log bucket"
+    actions = ["s3:Get*","s3:List*"]
+    effect   = "Allow"
+    resources = [aws_s3_bucket.sentinel_logs.arn]
+    principals {
+      type = "AWS"
+      identifiers = [aws_iam_role.sentinel_role.arn]
+    }
+  }
+
+  statement {
+    sid = "Allow GuardDuty to use the getBucketLocation operation"
+    actions = ["s3:GetBucketLocation"]
+    effect = "Allow"
+    resources = [aws_s3_bucket.sentinel_logs.arn]
+    principals {
+        type = "Service"
+        identifiers = ["guardduty.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid = "Allow GuardDuty to upload objects to the bucket"
+    actions = ["s3:PutObject"]
+    effect = "Allow"
+    resources = ["${aws_s3_bucket.sentinel_logs.arn}/*"]
+    principals {
+        type = "Service"
+        identifiers = ["guardduty.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid = "Deny GuardDuty unencrypted object uploads."
+    actions = ["s3:PutObject"]
+    effect = "Deny"
+    resources = ["${aws_s3_bucket.sentinel_logs.arn}/*"]
+    principals {
+        type = "Service"
+        identifiers = ["guardduty.amazonaws.com"]
+    }
+    condition {
+      test = "StringNotEquals"
+      variable = "s3:x-amz-server-side-encryption"
+      values = ["aws:kms"]
+    }
+  }
+
+  statement {
+    sid = "Deny GuardDuty incorrect encryption header."
+    actions = ["s3:PutObject"]
+    effect = "Deny"
+    resources = ["${aws_s3_bucket.sentinel_logs.arn}/*"]
+    principals {
+        type = "Service"
+        identifiers = ["guardduty.amazonaws.com"]
+    }
+    condition {
+      test = "StringNotEquals"
+      variable = "s3:x-amz-server-side-encryption-aws-kms-key-id"
+      values = [aws_kms_key.sentinel_guard_duty.arn]
+    }
+  }
+
+  statement {
+    sid = "Deny non-HTTPS access."
+    actions = ["s3:*"]
+    effect = "Deny"
+    resources = ["${aws_s3_bucket.sentinel_logs.arn}/*"]
+    principals {
+        type = "Service"
+        identifiers = ["guardduty.amazonaws.com"]
+    }
+    condition {
+      test = "Bool"
+      variable = "aws:SecureTransport"
+      values = ["false"]
+    }
+  }
+  
+}

--- a/org-master/sqs.tf
+++ b/org-master/sqs.tf
@@ -1,0 +1,39 @@
+resource "aws_sqs_queue" "sentinel_flowlog_queue" {
+  provider = aws.master
+  name     = "microsoft-sentinel-s3-flowlog"
+  tags     = {
+    Operator = "Microsoft_Sentinel_Automation_Script"
+  }
+}
+
+resource "aws_sqs_queue" "sentinel_guardduty_queue" {
+  provider = aws.master
+  name     = "microsoft-sentinel-s3-guardduty"
+  tags     = {
+    Operator = "Microsoft_Sentinel_Automation_Script"
+  }
+}
+
+resource "aws_sqs_queue_policy" "sentinel_flowlog_queue" {
+  provider  = aws.master
+  queue_url = aws_sqs_queue.sentinel_flowlog_queue.id
+  policy    = templatefile("${path.module}/policies/s3-sqs.json",
+    {
+      aws_sqs_queue_arn = aws_sqs_queue.sentinel_flowlog_queue.arn
+      aws_s3_bucket_arn = aws_s3_bucket.sentinel_logs.arn
+      aws_iam_role_arn = aws_iam_role.sentinel_role.arn
+    }
+  )
+}
+
+resource "aws_sqs_queue_policy" "sentinel_guardduty_queue" {
+  provider  = aws.master
+  queue_url = aws_sqs_queue.sentinel_guardduty_queue.id
+  policy    = templatefile("${path.module}/policies/s3-sqs.json",
+    {
+      aws_sqs_queue_arn = aws_sqs_queue.sentinel_guardduty_queue.arn
+      aws_s3_bucket_arn = aws_s3_bucket.sentinel_logs.arn
+      aws_iam_role_arn = aws_iam_role.sentinel_role.arn
+    }
+  )
+}

--- a/org-member/vpc-flowlog.tf
+++ b/org-member/vpc-flowlog.tf
@@ -30,3 +30,15 @@ resource "aws_flow_log" "vpc_log" {
   vpc_id = tolist(data.aws_vpcs.vpcs.ids)[count.index]
   traffic_type = "ALL"
 }
+
+resource "aws_flow_log" "sentinel_vpc_log" {
+  provider = aws.member
+  for_each = data.aws_vpcs.vpcs.ids
+  log_destination_type = "s3"
+  log_destination = var.org["sentinel_vpc_s3_bucket"]
+  vpc_id = each.key
+  traffic_type = "ALL"
+  tags = {
+    "Name" = "sentinel-vpc-log"
+  }
+}

--- a/soc-integration/sentinel.tf
+++ b/soc-integration/sentinel.tf
@@ -3,7 +3,7 @@
 resource "aws_iam_role" "azure_sentinel" {
   provider = aws.member
   name = "AzureSentinelRole"
-
+  description = "Role used by the Sentinel legacy CloudTrail connector (https://docs.microsoft.com/en-us/azure/sentinel/connect-aws?tabs=ct)"
   assume_role_policy = jsonencode({
   Version = "2012-10-17"
   Statement = [


### PR DESCRIPTION
Makes the following changes:
- Add an IAM role for the Sentinel S3 connector.
- Create S3 bucket in the Master account for collecting the logs.
- Configure GuardDuty with S3 publishing destination.
- Amend GD Finding "publishing frequency" to 15 mins.
- Add 2 SQS queues for:
  - Guard Duty
  - VPC Flow Logs
- Add a VPC flow log per Member account to write to the Master S3 bucket. 
- Add a description to the legacy CloudTrail connector role to differentiate from the S3 connector role.