### PR TITLE
AWS Backup - Daily / Weekly / Monthly policy

### DIFF
--- a/org-master/org.tf
+++ b/org-master/org.tf
@@ -24,3 +24,28 @@ resource "aws_organizations_policy" "org_policy" {
   name = "default-pollicy"
   content = file("${path.module}/policies/org-policy.json")
 }
+
+resource "aws_organizations_policy" "backup_daily8_weekly5_monthly14" {
+  provider = aws.master
+  name = "daily8-weekly5-monthly14"
+  description = "Daily (weekdays), retained for 8 days. Weekly (Saturday), retained for 5 weeks (35 days). Monthly (1st), retained for 14 months (420 days)."
+  type = "BACKUP_POLICY"
+  content = templatefile("${path.module}/policies/org-policy-backup-dwm.json",
+    {
+      aws_account_id = data.aws_caller_identity.master.account_id
+      aws_region = data.aws_region.master.name
+      backup_policy_label = "daily8-weekly5-monthly14"
+      daily_job_cron = "25 22 ? * 2,3,4,5,6 *"
+      daily_job_retention_days = 8
+      weekly_job_cron = "35 21 ? * 7 *"
+      weekly_job_retention_days = 35
+      monthly_job_cron = "45 22 1 * ? *"    
+      monthly_job_retention_days = 420
+      monthly_job_cold_storage_days = 5
+    }
+  )
+  tags = {
+      "backup-policy-type" = "dit-central-backup"
+      "backup-policy-name" = "daily8-weekly5-monthly14"
+  }
+}

--- a/org-master/org.tf
+++ b/org-master/org.tf
@@ -11,7 +11,11 @@ resource "aws_organizations_organization" "org" {
     "fms.amazonaws.com",
     "cloudtrail.amazonaws.com",
     "config.amazonaws.com",
-    "sso.amazonaws.com"
+    "sso.amazonaws.com",
+    "backup.amazonaws.com"
+  ]
+  enabled_policy_types = [
+    "BACKUP_POLICY"
   ]
 }
 

--- a/org-master/output.tf
+++ b/org-master/output.tf
@@ -12,7 +12,7 @@ output "org_master" {
             "config_role_arn" = aws_iam_role.master_config_role.arn,
             "config_role_name" = aws_iam_role.master_config_role.name,
             "guardduty_id"=  aws_guardduty_detector.master.id,
-            sentinel_vpc_s3_bucket = "${aws_s3_bucket.sentinel_logs.arn}/${local.sentinel_vpc_flow_log_folder}"
+            "sentinel_vpc_s3_bucket" = "${aws_s3_bucket.sentinel_logs.arn}/${local.sentinel_vpc_flow_log_folder}",
             "bastion_account" = var.org["bastion_account"]
           })
 }

--- a/org-master/output.tf
+++ b/org-master/output.tf
@@ -5,6 +5,7 @@ output "org_master" {
             "aws_profile" = var.org["aws_profile"],
             "organization_arn" = aws_organizations_organization.org.arn,
             "organization_id" = aws_organizations_organization.org.id,
+            "organization_policy_backup_d8w5m14" = aws_organizations_policy.backup_daily8_weekly5_monthly14.id,
             "cloudtrail_arn" = aws_cloudtrail.trail.arn,
             "cloudwatch_eventbus_arn" = "arn:aws:events:${data.aws_region.master.name}:${data.aws_caller_identity.master.account_id}:event-bus/default",
             "config_id" = aws_config_configuration_recorder.master_config.id,

--- a/org-master/policies/org-policy-backup-dwm.json
+++ b/org-master/policies/org-policy-backup-dwm.json
@@ -1,0 +1,144 @@
+{
+    "plans": {
+        "test-plan": {
+            "regions": {
+                "@@assign": [
+                    "${aws_region}"
+                ]
+            },
+            "rules": {
+                "daily": {
+                    "schedule_expression": {
+                        "@@assign": "cron(${daily_job_cron})"
+                    },
+                    "start_backup_window_minutes": {
+                        "@@assign": "60"
+                    },
+                    "complete_backup_window_minutes": {
+                        "@@assign": "360"
+                    },
+                    "lifecycle": {
+                        "delete_after_days": {
+                            "@@assign": "${daily_job_retention_days}"
+                        }
+                    },
+                    "target_backup_vault_name": {
+                        "@@assign": "${backup_policy_label}"
+                    },
+                    "recovery_point_tags": {
+                        "backup-policy-name": {
+                            "tag_key": {
+                                "@@assign": "backup-policy-name"
+                            },
+                            "tag_value": {
+                                "@@assign": "${backup_policy_label}"
+                            }
+                        },
+                        "backup-policy-rule": {
+                            "tag_key": {
+                                "@@assign": "backup-policy-rule"
+                            },
+                            "tag_value": {
+                                "@@assign": "daily"
+                            }
+                        }
+                    }
+                },
+                "weekly": {
+                    "schedule_expression": {
+                        "@@assign": "cron(${weekly_job_cron})"
+                    },
+                    "start_backup_window_minutes": {
+                        "@@assign": "120"
+                    },
+                    "complete_backup_window_minutes": {
+                        "@@assign": "1440"
+                    },
+                    "lifecycle": {
+                        "delete_after_days": {
+                            "@@assign": "${weekly_job_retention_days}"
+                        }
+                    },
+                    "target_backup_vault_name": {
+                        "@@assign": "${backup_policy_label}"
+                    },
+                    "recovery_point_tags": {
+                        "backup-policy-name": {
+                            "tag_key": {
+                                "@@assign": "backup-policy-name"
+                            },
+                            "tag_value": {
+                                "@@assign": "${backup_policy_label}"
+                            }
+                        },
+                        "backup-policy-rule": {
+                            "tag_key": {
+                                "@@assign": "backup-policy-rule"
+                            },
+                            "tag_value": {
+                                "@@assign": "weekly"
+                            }
+                        }
+                    }
+                },
+                "monthly": {
+                    "schedule_expression": {
+                        "@@assign": "cron(${monthly_job_cron})"
+                    },
+                    "start_backup_window_minutes": {
+                        "@@assign": "60"
+                    },
+                    "complete_backup_window_minutes": {
+                        "@@assign": "360"
+                    },
+                    "lifecycle": {
+                        "move_to_cold_storage_after_days": {
+                            "@@assign": "${monthly_job_cold_storage_days}"
+                        },
+                        "delete_after_days": {
+                            "@@assign": "${monthly_job_retention_days}"
+                        }
+                    },
+                    "target_backup_vault_name": {
+                        "@@assign": "${backup_policy_label}"
+                    },
+                    "recovery_point_tags": {
+                        "backup-policy-name": {
+                            "tag_key": {
+                                "@@assign": "backup-policy-name"
+                            },
+                            "tag_value": {
+                                "@@assign": "${backup_policy_label}"
+                            }
+                        },
+                        "backup-policy-rule": {
+                            "tag_key": {
+                                "@@assign": "backup-policy-rule"
+                            },
+                            "tag_value": {
+                                "@@assign": "monthly"
+                            }
+                        }
+                    }
+                }
+            },
+            "selections": {
+                "tags": {
+                    "dit-central-backup": {
+                        "iam_role_arn": {
+                            "@@assign": "arn:aws:iam::$account:role/AWSServiceRoleForBackup"
+                        },
+                        "tag_key": {
+                            "@@assign": "dit-central-backup"
+                        },
+                        "tag_value": {
+                            "@@assign": [
+                                "${backup_policy_label}"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/org-member/backup.tf
+++ b/org-member/backup.tf
@@ -8,3 +8,9 @@ resource "aws_backup_vault" "daily8_weekly5_monthly14" {
   name = "daily8-weekly5-monthly14"
   kms_key_arn = data.aws_kms_key.aws_backup.arn
 }
+
+resource "aws_organizations_policy_attachment" "backup_daily8_weekly5_monthly14" {
+  provider = aws.master
+  policy_id = var.org["organization_policy_backup_d8w5m14"]
+  target_id = data.aws_caller_identity.member.account_id
+}

--- a/org-member/backup.tf
+++ b/org-member/backup.tf
@@ -1,0 +1,10 @@
+data "aws_kms_key" "aws_backup" {
+  provider = aws.member
+  key_id = "alias/aws/backup"
+}
+
+resource "aws_backup_vault" "daily8_weekly5_monthly14" {
+  provider = aws.member
+  name = "daily8-weekly5-monthly14"
+  kms_key_arn = data.aws_kms_key.aws_backup.arn
+}


### PR DESCRIPTION
Makes the following changes:
- Adds "backup" to the service principals for which org integration is enabled.
- Enables "Backup policies" in Organisation Policies.
- Create organisation backup policy "backup_daily8_weekly5_monthly14" (numbers signify retention times)
  - Attach each member account to the policy.
- Create a "daily8-weekly5-monthly14" backup vault per member account.