### PR TITLE
Update aws_flow_log.vpc_log from a List to a Map

### DIFF
--- a/org-master/vpc-flowlog.tf
+++ b/org-master/vpc-flowlog.tf
@@ -24,10 +24,10 @@ resource "aws_s3_bucket" "vpc_log" {
 
 resource "aws_flow_log" "vpc_log" {
   provider = aws.master
-  count = length(data.aws_vpcs.vpcs.ids)
+  for_each = data.aws_vpcs.vpcs.ids
   log_destination_type = "s3"
-  log_destination = "${aws_s3_bucket.vpc_log.arn}/${tolist(data.aws_vpcs.vpcs.ids)[count.index]}"
-  vpc_id = tolist(data.aws_vpcs.vpcs.ids)[count.index]
+  log_destination = "${aws_s3_bucket.vpc_log.arn}/${each.key}"
+  vpc_id = each.key
   traffic_type = "ALL"
 }
 

--- a/org-member/vpc-flowlog.tf
+++ b/org-member/vpc-flowlog.tf
@@ -24,10 +24,10 @@ resource "aws_s3_bucket" "vpc_log" {
 
 resource "aws_flow_log" "vpc_log" {
   provider = aws.member
-  count = length(data.aws_vpcs.vpcs.ids)
+  for_each = data.aws_vpcs.vpcs.ids
   log_destination_type = "s3"
-  log_destination = "${aws_s3_bucket.vpc_log.arn}/${tolist(data.aws_vpcs.vpcs.ids)[count.index]}"
-  vpc_id = tolist(data.aws_vpcs.vpcs.ids)[count.index]
+  log_destination = "${aws_s3_bucket.vpc_log.arn}/${each.key}"
+  vpc_id = each.key
   traffic_type = "ALL"
 }
 


### PR DESCRIPTION
Makes the following change:
- Updates the `aws_flow_log.vpc_log` resource from a **list** type to a **map**

Prevents the flow-log configuration being replaced if a new VPC flow log is introduced (in the middle of a list)

Such as:
```
# module.ZZZ.aws_flow_log.vpc_log[0] must be replaced
      ~ vpc_id = "vpc-BBB” -> "vpc-AAA” # forces replacement
# module.ZZZ.aws_flow_log.vpc_log[1] must be replaced
      ~ vpc_id = "vpc-CCC” -> "vpc-BBB” # forces replacement
# module.ZZZ.aws_flow_log.vpc_log[2] must be replaced
      ~ vpc_id = "vpc-DDD” -> "vpc-CCC” # forces replacement
# module.ZZZ.aws_flow_log.vpc_log[3] must be replaced
      ~ vpc_id = "vpc-EEE” -> "vpc-DDD” # forces replacement
# module.ZZZ.aws_flow_log.vpc_log[4] will be created
      + vpc_id = "vpc-AAA”
```