### PR TITLE
Backup fixes - RDS and EBS

### DIFF
--- a/org-master/backup.tf
+++ b/org-master/backup.tf
@@ -28,6 +28,38 @@ resource "aws_lambda_function" "aws_backup_to_slack" {
 
 ## IAM
 
+resource "aws_iam_role" "dit_backup" {
+  provider = aws.master
+  name = "dit-aws-backup"
+  description = "Role used by AWS Backup for performing backups."
+  assume_role_policy = data.aws_iam_policy_document.dit_backup.json
+}
+
+data "aws_iam_policy_document" "dit_backup" {
+  provider = aws.master
+  statement {
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type = "Service"
+      identifiers = ["backup.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "dit_backup" {
+  provider = aws.master
+  name = "dit-aws-backup"
+  description = "Policy used by AWS Backup role for performing backups."
+  policy = file("${path.module}/policies/backup-policy.json")
+}
+
+resource "aws_iam_role_policy_attachment" "dit_backup_aws_linked_role_policy" {
+  provider = aws.master
+  role = aws_iam_role.dit_backup.name
+  policy_arn = aws_iam_policy.dit_backup.arn
+}
+
 resource "aws_iam_role" "aws_backup_to_slack" {
   provider = aws.master
   name = "aws-backup-to-slack"

--- a/org-master/org.tf
+++ b/org-master/org.tf
@@ -34,6 +34,7 @@ resource "aws_organizations_policy" "backup_daily8_weekly5_monthly14" {
     {
       aws_account_id = data.aws_caller_identity.master.account_id
       aws_region = data.aws_region.master.name
+      iam_role = aws_iam_role.dit_backup.name
       backup_policy_label = "daily8-weekly5-monthly14"
       daily_job_cron = "15 22 ? * 2,3,4,5,6 *"
       daily_job_retention_days = 8

--- a/org-master/policies/backup-policy.json
+++ b/org-master/policies/backup-policy.json
@@ -1,0 +1,293 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticfilesystem:Backup",
+                "elasticfilesystem:DescribeTags"
+            ],
+            "Resource": "arn:aws:elasticfilesystem:*:*:file-system/*",
+            "Condition": {
+                "StringLike": {
+                    "aws:ResourceTag/aws:elasticfilesystem:default-backup": "enabled"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "tag:GetResources",
+                "elasticfilesystem:DescribeFileSystems",
+                "dynamodb:ListTables",
+                "storagegateway:ListVolumes",
+                "ec2:DescribeVolumes",
+                "ec2:DescribeInstances",
+                "rds:DescribeDBInstances",
+                "rds:DescribeDBClusters",
+                "fsx:DescribeFileSystems",
+                "fsx:DescribeVolumes",
+                "s3:ListAllMyBuckets",
+                "s3:GetBucketTagging"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "ec2:CreateTags",
+            "Resource": "arn:aws:ec2:*::snapshot/*",
+            "Condition": {
+                "StringEquals": {
+                    "ec2:CreateAction": "CopySnapshot"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": "ec2:CreateTags",
+            "Resource": [
+                "arn:aws:ec2:*::image/*",
+                "arn:aws:ec2:*::snapshot/*"
+            ],
+            "Condition": {
+                "ForAllValues:StringEquals": {
+                    "aws:TagKeys": [
+                        "AWSBackupManagedResource"
+                    ]
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": "ec2:CreateTags",
+            "Resource": [
+                "arn:aws:ec2:*::image/*",
+                "arn:aws:ec2:*::snapshot/*"
+            ],
+            "Condition": {
+                "Null": {
+                    "ec2:ResourceTag/AWSBackupManagedResource": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeSnapshots",
+                "ec2:DescribeImages",
+                "rds:DescribeDBSnapshots",
+                "rds:DescribeDBClusterSnapshots"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "ec2:CopySnapshot",
+            "Resource": "arn:aws:ec2:*::snapshot/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "ec2:CopyImage",
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DeregisterImage",
+                "ec2:DeleteSnapshot"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "ec2:ResourceTag/AWSBackupManagedResource": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "rds:AddTagsToResource",
+                "rds:CopyDBSnapshot",
+                "rds:DeleteDBSnapshot"
+            ],
+            "Resource": "arn:aws:rds:*:*:snapshot:awsbackup:*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "rds:AddTagsToResource",
+                "rds:CopyDBClusterSnapshot",
+                "rds:DeleteDBClusterSnapshot"
+            ],
+            "Resource": "arn:aws:rds:*:*:cluster-snapshot:awsbackup:*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "kms:DescribeKey",
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "kms:ListGrants",
+                "kms:ReEncryptFrom",
+                "kms:GenerateDataKeyWithoutPlaintext"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringLike": {
+                    "kms:ViaService": [
+                        "ec2.*.amazonaws.com",
+                        "rds.*.amazonaws.com",
+                        "fsx.*.amazonaws.com"
+                    ]
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": "kms:CreateGrant",
+            "Resource": "*",
+            "Condition": {
+                "Bool": {
+                    "kms:GrantIsForAWSResource": "true"
+                },
+                "StringLike": {
+                    "kms:ViaService": [
+                        "ec2.*.amazonaws.com",
+                        "rds.*.amazonaws.com",
+                        "fsx.*.amazonaws.com"
+                    ]
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "fsx:CopyBackup",
+                "fsx:TagResource",
+                "fsx:DescribeBackups",
+                "fsx:DeleteBackup"
+            ],
+            "Resource": "arn:aws:fsx:*:*:backup/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "dynamodb:DeleteBackup",
+            "Resource": "arn:aws:dynamodb:*:*:table/*/backup/*"
+        },
+        {
+            "Sid": "BackupGateway",
+            "Effect": "Allow",
+            "Action": [
+                "backup-gateway:ListVirtualMachines"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "ListTagsForBackupGateway",
+            "Effect": "Allow",
+            "Action": [
+                "backup-gateway:ListTagsForResource"
+            ],
+            "Resource": "arn:aws:backup-gateway:*:*:vm/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "dynamodb:ListTagsOfResource",
+                "dynamodb:DescribeTable"
+            ],
+            "Resource": "arn:aws:dynamodb:*:*:table/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "storagegateway:DescribeCachediSCSIVolumes",
+                "storagegateway:DescribeStorediSCSIVolumes"
+            ],
+            "Resource": "arn:aws:storagegateway:*:*:gateway/*/volume/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "events:DeleteRule",
+                "events:PutTargets",
+                "events:DescribeRule",
+                "events:EnableRule",
+                "events:PutRule",
+                "events:RemoveTargets",
+                "events:ListTargetsByRule",
+                "events:DisableRule"
+            ],
+            "Resource": [
+                "arn:aws:events:*:*:rule/AwsBackupManagedRule*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": "events:ListRules",
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "sysops-sap:GetOperation",
+                "ssm-sap:GetOperation"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "timestream:ListDatabases",
+                "timestream:ListTables",
+                "timestream:ListTagsForResource",
+                "timestream:DescribeDatabase",
+                "timestream:DescribeTable",
+                "timestream:GetAwsBackupStatus",
+                "timestream:GetAwsRestoreStatus"
+            ],
+            "Resource": [
+                "arn:aws:timestream:*:*:database/*/table/*",
+                "arn:aws:timestream:*:*:database/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "timestream:DescribeEndpoints"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "redshift:DescribeClusterSnapshots",
+                "redshift:DescribeTags"
+            ],
+            "Resource": [
+                "arn:aws:redshift:*:*:snapshot:*/*",
+                "arn:aws:redshift:*:*:cluster:*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "redshift:DeleteClusterSnapshot"
+            ],
+            "Resource": [
+                "arn:aws:redshift:*:*:snapshot:*/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "redshift:DescribeClusters"
+            ],
+            "Resource": [
+                "arn:aws:redshift:*:*:cluster:*"
+            ]
+        }
+    ]
+}

--- a/org-master/policies/backup-policy.json
+++ b/org-master/policies/backup-policy.json
@@ -279,8 +279,12 @@
             "Effect": "Allow",
             "Action": [
                 "rds:ListTagsForResource",
+                "rds:CreateDBSnapshot"
             ],
-            "Resource": "arn:aws:rds:*:*:db:*"
+            "Resource": [
+                "arn:aws:rds:*:*:snapshot:*",
+                "arn:aws:rds:*:*:db:*"
+            ]
         }
     ]
 }

--- a/org-master/policies/backup-policy.json
+++ b/org-master/policies/backup-policy.json
@@ -78,8 +78,16 @@
         },
         {
             "Effect": "Allow",
-            "Action": "ec2:CopySnapshot",
-            "Resource": "arn:aws:ec2:*::snapshot/*"
+            "Action": [
+                "ec2:CopySnapshot",
+                "ec2:CreateSnapshots",
+                "ec2:CreateSnapshot"
+            ],
+            "Resource": [
+                "arn:aws:ec2:*::snapshot/*",
+                "arn:aws:ec2:*:*:volume/*",
+                "arn:aws:ec2:*:*:instance/*"
+            ]
         },
         {
             "Effect": "Allow",

--- a/org-master/policies/backup-policy.json
+++ b/org-master/policies/backup-policy.json
@@ -232,14 +232,6 @@
         {
             "Effect": "Allow",
             "Action": [
-                "sysops-sap:GetOperation",
-                "ssm-sap:GetOperation"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
                 "timestream:ListDatabases",
                 "timestream:ListTables",
                 "timestream:ListTagsForResource",

--- a/org-master/policies/backup-policy.json
+++ b/org-master/policies/backup-policy.json
@@ -31,12 +31,7 @@
         {
             "Effect": "Allow",
             "Action": "ec2:CreateTags",
-            "Resource": "arn:aws:ec2:*::snapshot/*",
-            "Condition": {
-                "StringEquals": {
-                    "ec2:CreateAction": "CopySnapshot"
-                }
-            }
+            "Resource": "arn:aws:ec2:*::snapshot/*"
         },
         {
             "Effect": "Allow",

--- a/org-master/policies/backup-policy.json
+++ b/org-master/policies/backup-policy.json
@@ -274,6 +274,13 @@
             "Resource": [
                 "arn:aws:redshift:*:*:cluster:*"
             ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "rds:ListTagsForResource",
+            ],
+            "Resource": "arn:aws:rds:*:*:db:*"
         }
     ]
 }

--- a/org-master/policies/backup-policy.json
+++ b/org-master/policies/backup-policy.json
@@ -18,6 +18,7 @@
                 "storagegateway:ListVolumes",
                 "ec2:DescribeVolumes",
                 "ec2:DescribeInstances",
+                "ec2:DescribeTags",
                 "rds:DescribeDBInstances",
                 "rds:DescribeDBClusters",
                 "fsx:DescribeFileSystems",

--- a/org-master/policies/backup-policy.json
+++ b/org-master/policies/backup-policy.json
@@ -244,9 +244,7 @@
                 "timestream:ListTables",
                 "timestream:ListTagsForResource",
                 "timestream:DescribeDatabase",
-                "timestream:DescribeTable",
-                "timestream:GetAwsBackupStatus",
-                "timestream:GetAwsRestoreStatus"
+                "timestream:DescribeTable"
             ],
             "Resource": [
                 "arn:aws:timestream:*:*:database/*/table/*",

--- a/org-master/policies/backup-policy.json
+++ b/org-master/policies/backup-policy.json
@@ -7,12 +7,7 @@
                 "elasticfilesystem:Backup",
                 "elasticfilesystem:DescribeTags"
             ],
-            "Resource": "arn:aws:elasticfilesystem:*:*:file-system/*",
-            "Condition": {
-                "StringLike": {
-                    "aws:ResourceTag/aws:elasticfilesystem:default-backup": "enabled"
-                }
-            }
+            "Resource": "arn:aws:elasticfilesystem:*:*:file-system/*"
         },
         {
             "Effect": "Allow",

--- a/org-master/policies/org-policy-backup-dwm.json
+++ b/org-master/policies/org-policy-backup-dwm.json
@@ -126,7 +126,7 @@
                 "tags": {
                     "dit-central-backup": {
                         "iam_role_arn": {
-                            "@@assign": "arn:aws:iam::$account:role/service-role/AWSBackupDefaultServiceRole"
+                            "@@assign": "arn:aws:iam::$account:role/${iam_role}"
                         },
                         "tag_key": {
                             "@@assign": "dit-central-backup"

--- a/org-member/backup.tf
+++ b/org-member/backup.tf
@@ -62,6 +62,38 @@ resource "aws_lambda_permission" "aws_lambda_from_member_sns" {
 
 ## IAM
 
+resource "aws_iam_role" "dit_backup" {
+  provider = aws.member
+  name = "dit-aws-backup"
+  description = "Role used by AWS Backup for performing backups."
+  assume_role_policy = data.aws_iam_policy_document.dit_backup.json
+}
+
+data "aws_iam_policy_document" "dit_backup" {
+  provider = aws.member
+  statement {
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type = "Service"
+      identifiers = ["backup.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "dit_backup" {
+  provider = aws.member
+  name = "dit-aws-backup"
+  description = "Policy used by AWS Backup role for performing backups."
+  policy = file("${path.module}/policies/backup-policy.json")
+}
+
+resource "aws_iam_role_policy_attachment" "dit_backup_aws_linked_role_policy" {
+  provider = aws.member
+  role = aws_iam_role.dit_backup.name
+  policy_arn = aws_iam_policy.dit_backup.arn
+}
+
 data "aws_iam_policy_document" "org_backup_sns" {
   provider = aws.member
   statement {
@@ -85,3 +117,37 @@ data "aws_iam_policy_document" "org_backup_sns" {
     resources = [aws_sns_topic.org_backup_sns.id]
   }
 }
+
+# resource "aws_iam_service_linked_role" "aws_backup_service_role" {
+#   aws_service_name = "backup.amazonaws.com"
+# }
+
+# # resource "aws_iam_role" "aws_backup_service_role" {
+# #   provider = aws.member
+# #   name = "AWSBackupDefaultServiceRole"
+# #   assume_role_policy = data.aws_iam_policy_document.aws_backup_service_role.json
+# # }
+
+# # data "aws_iam_policy_document" "aws_backup_service_role" {
+# #   provider = aws.member
+# #   statement {
+# #     effect = "Allow"
+# #     actions = ["sts:AssumeRole"]
+# #     principals {
+# #       type = "Service"
+# #       identifiers = ["backup.amazonaws.com"]
+# #     }
+# #   }
+# # }
+
+# # resource "aws_iam_role_policy_attachment" "service_role_backup_policy" {
+# #   provider = aws.member
+# #   role = aws_iam_role.aws_backup_service_role.name
+# #   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
+# # }
+
+# # resource "aws_iam_role_policy_attachment" "service_role_restore_policy" {
+# #   provider = aws.member
+# #   role = aws_iam_role.aws_backup_service_role.name
+# #   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores"
+# # }

--- a/org-member/backup.tf
+++ b/org-member/backup.tf
@@ -117,37 +117,3 @@ data "aws_iam_policy_document" "org_backup_sns" {
     resources = [aws_sns_topic.org_backup_sns.id]
   }
 }
-
-# resource "aws_iam_service_linked_role" "aws_backup_service_role" {
-#   aws_service_name = "backup.amazonaws.com"
-# }
-
-# # resource "aws_iam_role" "aws_backup_service_role" {
-# #   provider = aws.member
-# #   name = "AWSBackupDefaultServiceRole"
-# #   assume_role_policy = data.aws_iam_policy_document.aws_backup_service_role.json
-# # }
-
-# # data "aws_iam_policy_document" "aws_backup_service_role" {
-# #   provider = aws.member
-# #   statement {
-# #     effect = "Allow"
-# #     actions = ["sts:AssumeRole"]
-# #     principals {
-# #       type = "Service"
-# #       identifiers = ["backup.amazonaws.com"]
-# #     }
-# #   }
-# # }
-
-# # resource "aws_iam_role_policy_attachment" "service_role_backup_policy" {
-# #   provider = aws.member
-# #   role = aws_iam_role.aws_backup_service_role.name
-# #   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
-# # }
-
-# # resource "aws_iam_role_policy_attachment" "service_role_restore_policy" {
-# #   provider = aws.member
-# #   role = aws_iam_role.aws_backup_service_role.name
-# #   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores"
-# # }

--- a/org-member/policies/backup-policy.json
+++ b/org-member/policies/backup-policy.json
@@ -1,0 +1,293 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticfilesystem:Backup",
+                "elasticfilesystem:DescribeTags"
+            ],
+            "Resource": "arn:aws:elasticfilesystem:*:*:file-system/*",
+            "Condition": {
+                "StringLike": {
+                    "aws:ResourceTag/aws:elasticfilesystem:default-backup": "enabled"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "tag:GetResources",
+                "elasticfilesystem:DescribeFileSystems",
+                "dynamodb:ListTables",
+                "storagegateway:ListVolumes",
+                "ec2:DescribeVolumes",
+                "ec2:DescribeInstances",
+                "rds:DescribeDBInstances",
+                "rds:DescribeDBClusters",
+                "fsx:DescribeFileSystems",
+                "fsx:DescribeVolumes",
+                "s3:ListAllMyBuckets",
+                "s3:GetBucketTagging"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "ec2:CreateTags",
+            "Resource": "arn:aws:ec2:*::snapshot/*",
+            "Condition": {
+                "StringEquals": {
+                    "ec2:CreateAction": "CopySnapshot"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": "ec2:CreateTags",
+            "Resource": [
+                "arn:aws:ec2:*::image/*",
+                "arn:aws:ec2:*::snapshot/*"
+            ],
+            "Condition": {
+                "ForAllValues:StringEquals": {
+                    "aws:TagKeys": [
+                        "AWSBackupManagedResource"
+                    ]
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": "ec2:CreateTags",
+            "Resource": [
+                "arn:aws:ec2:*::image/*",
+                "arn:aws:ec2:*::snapshot/*"
+            ],
+            "Condition": {
+                "Null": {
+                    "ec2:ResourceTag/AWSBackupManagedResource": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeSnapshots",
+                "ec2:DescribeImages",
+                "rds:DescribeDBSnapshots",
+                "rds:DescribeDBClusterSnapshots"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "ec2:CopySnapshot",
+            "Resource": "arn:aws:ec2:*::snapshot/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "ec2:CopyImage",
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DeregisterImage",
+                "ec2:DeleteSnapshot"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "ec2:ResourceTag/AWSBackupManagedResource": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "rds:AddTagsToResource",
+                "rds:CopyDBSnapshot",
+                "rds:DeleteDBSnapshot"
+            ],
+            "Resource": "arn:aws:rds:*:*:snapshot:awsbackup:*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "rds:AddTagsToResource",
+                "rds:CopyDBClusterSnapshot",
+                "rds:DeleteDBClusterSnapshot"
+            ],
+            "Resource": "arn:aws:rds:*:*:cluster-snapshot:awsbackup:*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "kms:DescribeKey",
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "kms:ListGrants",
+                "kms:ReEncryptFrom",
+                "kms:GenerateDataKeyWithoutPlaintext"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringLike": {
+                    "kms:ViaService": [
+                        "ec2.*.amazonaws.com",
+                        "rds.*.amazonaws.com",
+                        "fsx.*.amazonaws.com"
+                    ]
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": "kms:CreateGrant",
+            "Resource": "*",
+            "Condition": {
+                "Bool": {
+                    "kms:GrantIsForAWSResource": "true"
+                },
+                "StringLike": {
+                    "kms:ViaService": [
+                        "ec2.*.amazonaws.com",
+                        "rds.*.amazonaws.com",
+                        "fsx.*.amazonaws.com"
+                    ]
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "fsx:CopyBackup",
+                "fsx:TagResource",
+                "fsx:DescribeBackups",
+                "fsx:DeleteBackup"
+            ],
+            "Resource": "arn:aws:fsx:*:*:backup/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "dynamodb:DeleteBackup",
+            "Resource": "arn:aws:dynamodb:*:*:table/*/backup/*"
+        },
+        {
+            "Sid": "BackupGateway",
+            "Effect": "Allow",
+            "Action": [
+                "backup-gateway:ListVirtualMachines"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "ListTagsForBackupGateway",
+            "Effect": "Allow",
+            "Action": [
+                "backup-gateway:ListTagsForResource"
+            ],
+            "Resource": "arn:aws:backup-gateway:*:*:vm/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "dynamodb:ListTagsOfResource",
+                "dynamodb:DescribeTable"
+            ],
+            "Resource": "arn:aws:dynamodb:*:*:table/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "storagegateway:DescribeCachediSCSIVolumes",
+                "storagegateway:DescribeStorediSCSIVolumes"
+            ],
+            "Resource": "arn:aws:storagegateway:*:*:gateway/*/volume/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "events:DeleteRule",
+                "events:PutTargets",
+                "events:DescribeRule",
+                "events:EnableRule",
+                "events:PutRule",
+                "events:RemoveTargets",
+                "events:ListTargetsByRule",
+                "events:DisableRule"
+            ],
+            "Resource": [
+                "arn:aws:events:*:*:rule/AwsBackupManagedRule*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": "events:ListRules",
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "sysops-sap:GetOperation",
+                "ssm-sap:GetOperation"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "timestream:ListDatabases",
+                "timestream:ListTables",
+                "timestream:ListTagsForResource",
+                "timestream:DescribeDatabase",
+                "timestream:DescribeTable",
+                "timestream:GetAwsBackupStatus",
+                "timestream:GetAwsRestoreStatus"
+            ],
+            "Resource": [
+                "arn:aws:timestream:*:*:database/*/table/*",
+                "arn:aws:timestream:*:*:database/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "timestream:DescribeEndpoints"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "redshift:DescribeClusterSnapshots",
+                "redshift:DescribeTags"
+            ],
+            "Resource": [
+                "arn:aws:redshift:*:*:snapshot:*/*",
+                "arn:aws:redshift:*:*:cluster:*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "redshift:DeleteClusterSnapshot"
+            ],
+            "Resource": [
+                "arn:aws:redshift:*:*:snapshot:*/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "redshift:DescribeClusters"
+            ],
+            "Resource": [
+                "arn:aws:redshift:*:*:cluster:*"
+            ]
+        }
+    ]
+}

--- a/org-member/policies/backup-policy.json
+++ b/org-member/policies/backup-policy.json
@@ -279,8 +279,12 @@
             "Effect": "Allow",
             "Action": [
                 "rds:ListTagsForResource",
+                "rds:CreateDBSnapshot"
             ],
-            "Resource": "arn:aws:rds:*:*:db:*"
+            "Resource": [
+                "arn:aws:rds:*:*:snapshot:*",
+                "arn:aws:rds:*:*:db:*"
+            ]
         }
     ]
 }

--- a/org-member/policies/backup-policy.json
+++ b/org-member/policies/backup-policy.json
@@ -78,8 +78,16 @@
         },
         {
             "Effect": "Allow",
-            "Action": "ec2:CopySnapshot",
-            "Resource": "arn:aws:ec2:*::snapshot/*"
+            "Action": [
+                "ec2:CopySnapshot",
+                "ec2:CreateSnapshots",
+                "ec2:CreateSnapshot"
+            ],
+            "Resource": [
+                "arn:aws:ec2:*::snapshot/*",
+                "arn:aws:ec2:*:*:volume/*",
+                "arn:aws:ec2:*:*:instance/*"
+            ]
         },
         {
             "Effect": "Allow",

--- a/org-member/policies/backup-policy.json
+++ b/org-member/policies/backup-policy.json
@@ -232,14 +232,6 @@
         {
             "Effect": "Allow",
             "Action": [
-                "sysops-sap:GetOperation",
-                "ssm-sap:GetOperation"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
                 "timestream:ListDatabases",
                 "timestream:ListTables",
                 "timestream:ListTagsForResource",

--- a/org-member/policies/backup-policy.json
+++ b/org-member/policies/backup-policy.json
@@ -31,12 +31,7 @@
         {
             "Effect": "Allow",
             "Action": "ec2:CreateTags",
-            "Resource": "arn:aws:ec2:*::snapshot/*",
-            "Condition": {
-                "StringEquals": {
-                    "ec2:CreateAction": "CopySnapshot"
-                }
-            }
+            "Resource": "arn:aws:ec2:*::snapshot/*"
         },
         {
             "Effect": "Allow",

--- a/org-member/policies/backup-policy.json
+++ b/org-member/policies/backup-policy.json
@@ -274,6 +274,13 @@
             "Resource": [
                 "arn:aws:redshift:*:*:cluster:*"
             ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "rds:ListTagsForResource",
+            ],
+            "Resource": "arn:aws:rds:*:*:db:*"
         }
     ]
 }

--- a/org-member/policies/backup-policy.json
+++ b/org-member/policies/backup-policy.json
@@ -18,6 +18,7 @@
                 "storagegateway:ListVolumes",
                 "ec2:DescribeVolumes",
                 "ec2:DescribeInstances",
+                "ec2:DescribeTags",
                 "rds:DescribeDBInstances",
                 "rds:DescribeDBClusters",
                 "fsx:DescribeFileSystems",

--- a/org-member/policies/backup-policy.json
+++ b/org-member/policies/backup-policy.json
@@ -244,9 +244,7 @@
                 "timestream:ListTables",
                 "timestream:ListTagsForResource",
                 "timestream:DescribeDatabase",
-                "timestream:DescribeTable",
-                "timestream:GetAwsBackupStatus",
-                "timestream:GetAwsRestoreStatus"
+                "timestream:DescribeTable"
             ],
             "Resource": [
                 "arn:aws:timestream:*:*:database/*/table/*",

--- a/org-member/policies/backup-policy.json
+++ b/org-member/policies/backup-policy.json
@@ -7,12 +7,7 @@
                 "elasticfilesystem:Backup",
                 "elasticfilesystem:DescribeTags"
             ],
-            "Resource": "arn:aws:elasticfilesystem:*:*:file-system/*",
-            "Condition": {
-                "StringLike": {
-                    "aws:ResourceTag/aws:elasticfilesystem:default-backup": "enabled"
-                }
-            }
+            "Resource": "arn:aws:elasticfilesystem:*:*:file-system/*"
         },
         {
             "Effect": "Allow",


### PR DESCRIPTION
Makes the following changes:
- Creates new `dit-aws-backup` Role.
- Creates new `dit-aws-backup` Policy based on `AWSBackupServiceLinkedRolePolicyForBackup` - with additions since RDS and EBS backups fail using the Service Linked Policy.
- Passes the role name through to the existing Org backup policy. Replaces `AWSBackupDefaultServiceRole` here.
