### PR TITLE
AWS-Managed IAM  policy lookup

### DIFF
--- a/org-member/config.tf
+++ b/org-member/config.tf
@@ -5,10 +5,15 @@ resource "aws_iam_role" "config_role" {
   assume_role_policy = file("${path.module}/policies/config-sts.json")
 }
 
+data "aws_iam_policy" "aws_config_service_role" {
+  provider = aws.member
+  name = var.member["aws_config_service_role"]
+}
+
 resource "aws_iam_role_policy_attachment" "config_policy" {
   provider = aws.member
   role = aws_iam_role.config_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSConfigRole"
+  policy_arn = data.aws_iam_policy.aws_config_service_role.arn
 }
 
 resource "aws_iam_policy" "config_service_policy" {

--- a/org-member/main.tf
+++ b/org-member/main.tf
@@ -13,6 +13,7 @@ variable "member" {
     "aws_shared_credentials_file" = "~/.aws/credentials"
     "aws_profile" = "default"
     "dev_access" = "false"
+    "aws_config_service_role" = "AWS_ConfigRole"
   }
 }
 

--- a/soc-integration/main.tf
+++ b/soc-integration/main.tf
@@ -3,6 +3,11 @@ variable "config" {
   default = {}
 }
 
+variable "member" {
+  type = map(string)
+  default = {}
+}
+
 terraform {
   required_providers {
     aws = {

--- a/soc-integration/sentinel.tf
+++ b/soc-integration/sentinel.tf
@@ -23,10 +23,15 @@ resource "aws_iam_role" "azure_sentinel" {
 })
 }
 
+data "aws_iam_policy" "cloudtrail_readonly" {
+  provider = aws.member
+  name = var.member["cloudtrail_readonly_policy"]
+}
+
 resource "aws_iam_role_policy_attachment" "cloudtrail_readonly" {
   provider = aws.member
   role = aws_iam_role.azure_sentinel.name
-  policy_arn = "arn:aws:iam::aws:policy/AWSCloudTrailReadOnlyAccess"
+  policy_arn = data.aws_iam_policy.cloudtrail_readonly.arn
 }
 
 output "azure-sentinel-role-arn" {


### PR DESCRIPTION
This removes the hard-coded ARNs for the following policies and instead gets them from the member map variable values (policy names)
- `arn:aws:iam::aws:policy/AWSCloudTrailReadOnlyAccess`
- `arn:aws:iam::aws:policy/service-role/AWSConfigRole`
