### PR TITLE
Convert VPC data list to a set (for_each).

### DIFF
--- a/org-master/vpc-flowlog.tf
+++ b/org-master/vpc-flowlog.tf
@@ -24,7 +24,7 @@ resource "aws_s3_bucket" "vpc_log" {
 
 resource "aws_flow_log" "vpc_log" {
   provider = aws.master
-  for_each = data.aws_vpcs.vpcs.ids
+  for_each = toset(data.aws_vpcs.vpcs.ids)
   log_destination_type = "s3"
   log_destination = "${aws_s3_bucket.vpc_log.arn}/${each.key}"
   vpc_id = each.key
@@ -33,7 +33,7 @@ resource "aws_flow_log" "vpc_log" {
 
 resource "aws_flow_log" "sentinel_vpc_log" {
   provider = aws.master
-  for_each = data.aws_vpcs.vpcs.ids
+  for_each = toset(data.aws_vpcs.vpcs.ids)
   log_destination_type = "s3"
   log_destination = "${aws_s3_bucket.sentinel_logs.arn}/${local.sentinel_vpc_flow_log_folder}"
   log_format = var.soc_config["sentinel_vpc_log_format"]

--- a/org-member/vpc-flowlog.tf
+++ b/org-member/vpc-flowlog.tf
@@ -24,7 +24,7 @@ resource "aws_s3_bucket" "vpc_log" {
 
 resource "aws_flow_log" "vpc_log" {
   provider = aws.member
-  for_each = data.aws_vpcs.vpcs.ids
+  for_each = toset(data.aws_vpcs.vpcs.ids)
   log_destination_type = "s3"
   log_destination = "${aws_s3_bucket.vpc_log.arn}/${each.key}"
   vpc_id = each.key
@@ -33,7 +33,7 @@ resource "aws_flow_log" "vpc_log" {
 
 resource "aws_flow_log" "sentinel_vpc_log" {
   provider = aws.member
-  for_each = data.aws_vpcs.vpcs.ids
+  for_each = toset(data.aws_vpcs.vpcs.ids)
   log_destination_type = "s3"
   log_destination = var.org["sentinel_vpc_s3_bucket"]
   log_format = var.soc_config["sentinel_vpc_log_format"]


### PR DESCRIPTION
Converts the VPC data resource output list to a set (for the for_each argument).
This resolves the error:

> Error: Invalid for_each argument
> ...is list of string with X elements
> The given "for_each" argument value is unsuitable: the "for_each" argument must be a map, or set of strings, and you have provided a value of type list of string.