### PR TITLE
Add Control Tower Execution Role to all accounts

### DIFF
--- a/org-common/iam.tf
+++ b/org-common/iam.tf
@@ -1,0 +1,25 @@
+# Control Tower
+
+resource "aws_iam_role" "control_tower_execution" {
+  provider = aws.common
+  name = "AWSControlTowerExecution"
+  assume_role_policy = data.aws_iam_policy_document.control_tower_execution.json
+}
+
+data "aws_iam_policy_document" "control_tower_execution" {
+  provider = aws.common
+  statement {
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type = "AWS"
+      identifiers = ["arn:aws:iam::${var.org["account_id"]}:root"]
+    }
+  }  
+}
+
+resource "aws_iam_role_policy_attachment" "control_tower_execution_admin_access" {
+  provider = aws.common
+  role = aws_iam_role.control_tower_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}

--- a/org-common/main.tf
+++ b/org-common/main.tf
@@ -1,0 +1,20 @@
+variable "org" {
+  type = map(string)
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      configuration_aliases = [ aws.common ]
+    }
+  }
+}
+
+data "aws_region" "common" {
+  provider = aws.common
+}
+
+data "aws_caller_identity" "common" {
+  provider = aws.common
+}

--- a/org-master/iam.tf
+++ b/org-master/iam.tf
@@ -164,6 +164,8 @@ resource "aws_iam_role_policy_attachment" "bastion_admin" {
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
 
+# Sentinel
+
 resource "aws_iam_role" "sentinel_role" {
   provider = aws.master
   name = var.soc_config["sentinel_role_name"]
@@ -194,6 +196,8 @@ resource "aws_iam_role_policy_attachment" "sentinel_s3_readonly" {
   role = aws_iam_role.sentinel_role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
 }
+
+# Control Tower
 
 resource "aws_iam_role" "control_tower_execution" {
   provider = aws.master

--- a/org-master/iam.tf
+++ b/org-master/iam.tf
@@ -196,29 +196,3 @@ resource "aws_iam_role_policy_attachment" "sentinel_s3_readonly" {
   role = aws_iam_role.sentinel_role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
 }
-
-# Control Tower
-
-resource "aws_iam_role" "control_tower_execution" {
-  provider = aws.master
-  name = "AWSControlTowerExecution"
-  assume_role_policy = data.aws_iam_policy_document.control_tower_execution.json
-}
-
-data "aws_iam_policy_document" "control_tower_execution" {
-  provider = aws.master
-  statement {
-    effect = "Allow"
-    actions = ["sts:AssumeRole"]
-    principals {
-      type = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.master.account_id}:root"]
-    }
-  }  
-}
-
-resource "aws_iam_role_policy_attachment" "control_tower_execution_admin_access" {
-  provider = aws.master
-  role = aws_iam_role.control_tower_execution.name
-  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
-}

--- a/org-master/iam.tf
+++ b/org-master/iam.tf
@@ -194,3 +194,27 @@ resource "aws_iam_role_policy_attachment" "sentinel_s3_readonly" {
   role = aws_iam_role.sentinel_role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
 }
+
+resource "aws_iam_role" "control_tower_execution" {
+  provider = aws.master
+  name = "AWSControlTowerExecution"
+  assume_role_policy = data.aws_iam_policy_document.control_tower_execution.json
+}
+
+data "aws_iam_policy_document" "control_tower_execution" {
+  provider = aws.master
+  statement {
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.master.account_id}:root"]
+    }
+  }  
+}
+
+resource "aws_iam_role_policy_attachment" "control_tower_execution_admin_access" {
+  provider = aws.master
+  role = aws_iam_role.control_tower_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}

--- a/org-master/kms.tf
+++ b/org-master/kms.tf
@@ -1,3 +1,5 @@
+# Sentinel
+
 resource "aws_kms_key" "sentinel_guard_duty" {
   provider = aws.master
   description = "Sentinel GuardDuty KMS Key"
@@ -15,6 +17,8 @@ resource "aws_kms_alias" "sentinel_guard_duty" {
   name = "alias/sentinel-guardduty-key"
   target_key_id = aws_kms_key.sentinel_guard_duty.key_id
 }
+
+# Control Tower
 
 resource "aws_kms_key" "control_tower" {
   provider = aws.master

--- a/org-member/iam.tf
+++ b/org-member/iam.tf
@@ -410,3 +410,27 @@ data "aws_iam_policy_document" "default_dev_policy" {
     }
   }
 }
+
+resource "aws_iam_role" "control_tower_execution" {
+  provider = aws.member
+  name = "AWSControlTowerExecution"
+  assume_role_policy = data.aws_iam_policy_document.control_tower_execution.json
+}
+
+data "aws_iam_policy_document" "control_tower_execution" {
+  provider = aws.member
+  statement {
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.master.account_id}:root"]
+    }
+  }  
+}
+
+resource "aws_iam_role_policy_attachment" "control_tower_execution_admin_access" {
+  provider = aws.member
+  role = aws_iam_role.control_tower_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}

--- a/org-member/iam.tf
+++ b/org-member/iam.tf
@@ -410,29 +410,3 @@ data "aws_iam_policy_document" "default_dev_policy" {
     }
   }
 }
-
-# Control Tower
-
-resource "aws_iam_role" "control_tower_execution" {
-  provider = aws.member
-  name = "AWSControlTowerExecution"
-  assume_role_policy = data.aws_iam_policy_document.control_tower_execution.json
-}
-
-data "aws_iam_policy_document" "control_tower_execution" {
-  provider = aws.member
-  statement {
-    effect = "Allow"
-    actions = ["sts:AssumeRole"]
-    principals {
-      type = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.master.account_id}:root"]
-    }
-  }  
-}
-
-resource "aws_iam_role_policy_attachment" "control_tower_execution_admin_access" {
-  provider = aws.member
-  role = aws_iam_role.control_tower_execution.name
-  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
-}

--- a/org-member/iam.tf
+++ b/org-member/iam.tf
@@ -411,6 +411,8 @@ data "aws_iam_policy_document" "default_dev_policy" {
   }
 }
 
+# Control Tower
+
 resource "aws_iam_role" "control_tower_execution" {
   provider = aws.member
   name = "AWSControlTowerExecution"


### PR DESCRIPTION
Makes the following IAM changes:
- Create `AWSControlTowerExecution` role across accounts.
- Add some comments to the TF files
