### PR TITLE
Organisation ID variable

### DIFF
--- a/org-master/iam.tf
+++ b/org-master/iam.tf
@@ -81,7 +81,7 @@ data "aws_iam_policy_document" "bastion_sts_readonly" {
     condition {
       test = "StringEquals"
       variable = "aws:PrincipalOrgID"
-      values = [element(split("/", aws_organizations_organization.org.id), 1)]
+      values = [local.aws_organization_id]
     }
     condition {
       test = "Bool"
@@ -138,7 +138,7 @@ data "aws_iam_policy_document" "bastion_sts_admin" {
     condition {
       test = "StringEquals"
       variable = "aws:PrincipalOrgID"
-      values = [element(split("/", aws_organizations_organization.org.id), 1)]
+      values = [local.aws_organization_id]
     }
     condition {
       test = "Bool"

--- a/org-master/local.tf
+++ b/org-master/local.tf
@@ -7,4 +7,5 @@ locals {
   sentinel_guardduty_folder = "GuardDuty"
   sentinel_cloudtrail_folder = "CloudTrail"
   sentinel_log_expiry_days = 14
+  aws_organization_id = element(split("/", aws_organizations_organization.org.id), 1)
 }

--- a/org-master/output.tf
+++ b/org-master/output.tf
@@ -4,7 +4,6 @@ output "org_master" {
             "aws_shared_credentials_file" = var.org["aws_shared_credentials_file"],
             "aws_profile" = var.org["aws_profile"],
             "organization_arn" = aws_organizations_organization.org.arn,
-            "organization_id" = aws_organizations_organization.org.id,
             "organization_policy_backup_d8w5m14" = aws_organizations_policy.backup_daily8_weekly5_monthly14.id,
             "backup_to_slack_lambda_arn" = aws_lambda_function.aws_backup_to_slack.arn
             "cloudtrail_arn" = aws_cloudtrail.trail.arn,

--- a/org-master/s3.tf
+++ b/org-master/s3.tf
@@ -207,7 +207,7 @@ data "aws_iam_policy_document" "sentinel_logs" {
     actions = ["s3:PutObject"]
     effect = "Allow"
     resources = [
-      "${aws_s3_bucket.sentinel_logs.arn}/CloudTrail/AWSLogs/${aws_organizations_organization.org.id}/*"
+      "${aws_s3_bucket.sentinel_logs.arn}/CloudTrail/AWSLogs/${local.aws_organization_id}/*"
     ]
     principals {
         type = "Service"

--- a/org-member/iam.tf
+++ b/org-member/iam.tf
@@ -152,7 +152,7 @@ data "aws_iam_policy_document" "bastion_sts_readonly" {
     condition {
       test = "StringEquals"
       variable = "aws:PrincipalOrgID"
-      values = [element(split("/", var.org["organization_arn"]), 1)]
+      values = [local.aws_organization_id]
     }
     condition {
       test = "Bool"
@@ -245,7 +245,7 @@ data "aws_iam_policy_document" "bastion_sts_admin" {
     condition {
       test = "StringEquals"
       variable = "aws:PrincipalOrgID"
-      values = [element(split("/", var.org["organization_arn"]), 1)]
+      values = [local.aws_organization_id]
     }
     condition {
       test = "Bool"
@@ -339,7 +339,7 @@ data "aws_iam_policy_document" "bastion_sts_dev" {
     condition {
       test = "StringEquals"
       variable = "aws:PrincipalOrgID"
-      values = [element(split("/", var.org["organization_arn"]), 1)]
+      values = [local.aws_organization_id]
     }
     condition {
       test = "Bool"

--- a/org-member/local.tf
+++ b/org-member/local.tf
@@ -3,4 +3,5 @@ locals {
   sentinel_common_resource_tag_name = "Operator"
   sentinel_common_resource_tag_value = "Microsoft_Sentinel_Automation_Script"
   sentinel_common_resource_tag = {"${local.sentinel_common_resource_tag_name}" = "${local.sentinel_common_resource_tag_value}"}
+  aws_organization_id = element(split("/", var.org["organization_arn"]), 1)
 }


### PR DESCRIPTION
Makes the following changes:
- Fixes issue in Org Master S3 bucket (Org ID not split).
- Add local variables and remove repeated split functions to extract the Org ID.