### PR TITLE
AWS Control Tower activation

### DIFF
--- a/org-master/cloudtrail.tf
+++ b/org-master/cloudtrail.tf
@@ -66,6 +66,8 @@ resource "aws_s3_bucket" "cloudtrail-s3" {
   policy = templatefile("${path.module}/policies/cloudtrail-s3.json",
     {
       cloudtrail_s3 = "cloudtrail-${data.aws_caller_identity.master.account_id}"
+      account_id = data.aws_caller_identity.master.account_id
+      organization_id = local.aws_organization_id
     }
   )
 }

--- a/org-master/org.tf
+++ b/org-master/org.tf
@@ -12,7 +12,8 @@ resource "aws_organizations_organization" "org" {
     "cloudtrail.amazonaws.com",
     "config.amazonaws.com",
     "sso.amazonaws.com",
-    "backup.amazonaws.com"
+    "backup.amazonaws.com",
+    "controltower.amazonaws.com"
   ]
   enabled_policy_types = [
     "BACKUP_POLICY"

--- a/org-master/org.tf
+++ b/org-master/org.tf
@@ -16,7 +16,8 @@ resource "aws_organizations_organization" "org" {
     "controltower.amazonaws.com"
   ]
   enabled_policy_types = [
-    "BACKUP_POLICY"
+    "BACKUP_POLICY",
+    "SERVICE_CONTROL_POLICY"
   ]
 }
 

--- a/org-master/policies/cloudtrail-s3.json
+++ b/org-master/policies/cloudtrail-s3.json
@@ -34,6 +34,50 @@
           "aws:SecureTransport": "false"
         }
       }
+    },
+    {
+      "Action": "s3:GetBucketAcl",
+      "Condition": {
+        "StringEquals": {
+          "AWS:SourceArn": "arn:aws:cloudtrail:eu-west-2:${account_id}:trail/${cloudtrail_s3}"
+        }
+      },
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "cloudtrail.amazonaws.com"
+      },
+      "Resource": "arn:aws:s3:::${cloudtrail_s3}",
+      "Sid": "AWSCloudTrailAclCheck20150319"
+    },
+    {
+      "Action": "s3:PutObject",
+      "Condition": {
+        "StringEquals": {
+          "AWS:SourceArn": "arn:aws:cloudtrail:eu-west-2:${account_id}:trail/${cloudtrail_s3}",
+          "s3:x-amz-acl": "bucket-owner-full-control"
+        }
+      },
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "cloudtrail.amazonaws.com"
+      },
+      "Resource": "arn:aws:s3:::${cloudtrail_s3}/AWSLogs/${account_id}/*",
+      "Sid": "AWSCloudTrailWrite20150319"
+    },
+    {
+      "Action": "s3:PutObject",
+      "Condition": {
+        "StringEquals": {
+          "AWS:SourceArn": "arn:aws:cloudtrail:eu-west-2:${account_id}:trail/${cloudtrail_s3}",
+          "s3:x-amz-acl": "bucket-owner-full-control"
+          }
+        },
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "cloudtrail.amazonaws.com"
+      },
+      "Resource": "arn:aws:s3:::${cloudtrail_s3}/AWSLogs/${organization_id}/*",
+      "Sid": "AWSCloudTrailWrite20150319"
     }
   ]
 }


### PR DESCRIPTION
Makes the following Organisation changes:
- Adds Control Tower to the list of service access principals.
- Adds SCPs to the list of enabled policy types
- Update CloudTrail S3 bucket policy.
  - _Documented here: [Create or update an Amazon S3 bucket to use to store the log files for an organization trail](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/create-s3-bucket-policy-for-cloudtrail.html#org-trail-bucket-policy)_
