### PR TITLE
AWS VPC Flow Log S3 bucket encryption

### DIFF
--- a/org-master/vpc-flowlog.tf
+++ b/org-master/vpc-flowlog.tf
@@ -22,6 +22,80 @@ resource "aws_s3_bucket" "vpc_log" {
   }
 }
 
+resource "aws_s3_bucket_policy" "vpc_log" {
+  provider = aws.master
+  bucket   = aws_s3_bucket.vpc_log.id
+  policy   = data.aws_iam_policy_document.vpc_log.json
+}
+
+data "aws_iam_policy_document" "vpc_log" {
+  provider = aws.master
+  version = "2012-10-17"
+  statement {
+    sid = "Deny non-HTTPS access."
+    principals {
+      type = "*"
+      identifiers = ["*"]
+    }
+    actions = ["s3:*"]
+    effect = "Deny"
+    resources = [
+      "${aws_s3_bucket.vpc_log.arn}",
+      "${aws_s3_bucket.vpc_log.arn}/*"
+    ]
+    condition {
+      test = "Bool"
+      variable = "aws:SecureTransport"
+      values = ["false"]
+    }
+  }
+  statement {
+    sid = "AWSLogDeliveryWrite"
+    principals {
+      type = "Service"
+      identifiers = ["delivery.logs.amazonaws.com"]
+    }
+    actions = ["s3:PutObject"]
+    effect = "Allow"
+    resources = ["${aws_s3_bucket.vpc_log.arn}/*"]
+    condition {
+      test = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values = ["bucket-owner-full-control"]
+    }
+    condition {
+      test = "StringEquals"
+      variable = "aws:SourceAccount"
+      values = [data.aws_caller_identity.master.account_id]
+    }
+    condition {
+      test = "ArnLike"
+      variable = "aws:SourceArn"
+      values = ["arn:aws:logs:${data.aws_region.master.name}:${data.aws_caller_identity.master.account_id}:*"]
+    }
+  }
+  statement {
+    sid = "AWSLogDeliveryAclCheck"
+    principals {
+      type = "Service"
+      identifiers = ["delivery.logs.amazonaws.com"]
+    }
+    actions = ["s3:GetBucketAcl"]
+    effect = "Allow"
+    resources = [aws_s3_bucket.vpc_log.arn]
+    condition {
+      test = "StringEquals"
+      variable = "aws:SourceAccount"
+      values = [data.aws_caller_identity.master.account_id]
+    }
+    condition {
+      test = "ArnLike"
+      variable = "aws:SourceArn"
+      values = ["arn:aws:logs:${data.aws_region.master.name}:${data.aws_caller_identity.master.account_id}:*"]
+    }
+  }
+}
+
 resource "aws_flow_log" "vpc_log" {
   provider = aws.master
   for_each = toset(data.aws_vpcs.vpcs.ids)

--- a/org-member/vpc-flowlog.tf
+++ b/org-member/vpc-flowlog.tf
@@ -22,6 +22,80 @@ resource "aws_s3_bucket" "vpc_log" {
   }
 }
 
+resource "aws_s3_bucket_policy" "vpc_log" {
+  provider = aws.member
+  bucket   = aws_s3_bucket.vpc_log.id
+  policy   = data.aws_iam_policy_document.vpc_log.json
+}
+
+data "aws_iam_policy_document" "vpc_log" {
+  provider = aws.member
+  version = "2012-10-17"
+  statement {
+    sid = "Deny non-HTTPS access."
+    principals {
+      type = "*"
+      identifiers = ["*"]
+    }
+    actions = ["s3:*"]
+    effect = "Deny"
+    resources = [
+      "${aws_s3_bucket.vpc_log.arn}",
+      "${aws_s3_bucket.vpc_log.arn}/*"
+    ]
+    condition {
+      test = "Bool"
+      variable = "aws:SecureTransport"
+      values = ["false"]
+    }
+  }
+  statement {
+    sid = "AWSLogDeliveryWrite"
+    principals {
+      type = "Service"
+      identifiers = ["delivery.logs.amazonaws.com"]
+    }
+    actions = ["s3:PutObject"]
+    effect = "Allow"
+    resources = ["${aws_s3_bucket.vpc_log.arn}/*"]
+    condition {
+      test = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values = ["bucket-owner-full-control"]
+    }
+    condition {
+      test = "StringEquals"
+      variable = "aws:SourceAccount"
+      values = [data.aws_caller_identity.member.account_id]
+    }
+    condition {
+      test = "ArnLike"
+      variable = "aws:SourceArn"
+      values = ["arn:aws:logs:${data.aws_region.member.name}:${data.aws_caller_identity.member.account_id}:*"]
+    }
+  }
+  statement {
+    sid = "AWSLogDeliveryAclCheck"
+    principals {
+      type = "Service"
+      identifiers = ["delivery.logs.amazonaws.com"]
+    }
+    actions = ["s3:GetBucketAcl"]
+    effect = "Allow"
+    resources = [aws_s3_bucket.vpc_log.arn]
+    condition {
+      test = "StringEquals"
+      variable = "aws:SourceAccount"
+      values = [data.aws_caller_identity.member.account_id]
+    }
+    condition {
+      test = "ArnLike"
+      variable = "aws:SourceArn"
+      values = ["arn:aws:logs:${data.aws_region.member.name}:${data.aws_caller_identity.member.account_id}:*"]
+    }
+  }
+}
+
 resource "aws_flow_log" "vpc_log" {
   provider = aws.member
   for_each = toset(data.aws_vpcs.vpcs.ids)


### PR DESCRIPTION
Makes the following changes:
- Adds a policy statement to deny access if `aws:SecureTransport` is false.
- Preserve permissions to the bucket and objects for the Log Delivery service.

Reference: [Amazon S3 security best practices](https://docs.aws.amazon.com/AmazonS3/latest/userguide/security-best-practices.html)

---

> _**Enforce encryption of data in transit**_
> _You can use HTTPS (TLS) to help prevent potential attackers from eavesdropping on or manipulating network traffic using person-in-the-middle or similar attacks. You should allow only encrypted connections over HTTPS (TLS) using the [aws:SecureTransport](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#condition-keys-securetransport) condition on Amazon S3 bucket policies._