### PR TITLE
Add Org OU resource and variable.

### DIFF
--- a/org-master/main.tf
+++ b/org-master/main.tf
@@ -53,3 +53,10 @@ variable "aws_regions" {
     "us-west-2"
   ]
 }
+
+variable "org_ou_structure" {
+  type = map(object({
+    ou_name   = string
+    parent_id = string
+  }))
+}

--- a/org-master/org.tf
+++ b/org-master/org.tf
@@ -52,3 +52,10 @@ resource "aws_organizations_policy" "backup_daily8_weekly5_monthly14" {
       "backup-policy-name" = "daily8-weekly5-monthly14"
   }
 }
+
+resource "aws_organizations_organizational_unit" "org_ou_structure" {
+  provider = aws.master
+  for_each = var.org_ou_structure
+  name = each.value["ou_name"]
+  parent_id = each.value["parent_id"]
+}


### PR DESCRIPTION
Makes the following changes:
- Adds an `aws_organizations_organizational_unit` resource to create the OU structure.
- Declares a `org_ou_structure` map of OU objects to define the OU structure.
