### PR TITLE
Enable AWS Inspector V2

### DIFF
--- a/org-master/inspector.tf
+++ b/org-master/inspector.tf
@@ -15,3 +15,27 @@ resource "aws_inspector_assessment_template" "default" {
   duration = 3600
   rules_package_arns = tolist(data.aws_inspector_rules_packages.rules.arns)
 }
+
+# AWS Inspector V2
+
+resource "aws_inspector2_delegated_admin_account" "master" {
+  provider = aws.master
+  account_id = data.aws_caller_identity.master.account_id
+}
+
+resource "aws_inspector2_enabler" "master" {
+  provider = aws.master
+  account_ids = [data.aws_caller_identity.master.account_id]
+  resource_types = ["ECR", "EC2", "LAMBDA"]
+  depends_on = [aws_inspector2_delegated_admin_account.master]
+}
+
+resource "aws_inspector2_organization_configuration" "master" {
+  provider = aws.master
+  auto_enable {
+    ec2 = true
+    ecr = true
+    lambda = true
+  }
+  depends_on = [aws_inspector2_enabler.master]
+}

--- a/org-master/org.tf
+++ b/org-master/org.tf
@@ -13,7 +13,8 @@ resource "aws_organizations_organization" "org" {
     "config.amazonaws.com",
     "sso.amazonaws.com",
     "backup.amazonaws.com",
-    "controltower.amazonaws.com"
+    "controltower.amazonaws.com",
+    "inspector2.amazonaws.com"
   ]
   enabled_policy_types = [
     "BACKUP_POLICY",

--- a/org-member/inspector.tf
+++ b/org-member/inspector.tf
@@ -19,7 +19,7 @@ resource "aws_inspector_assessment_template" "default" {
 # AWS Inspector V2
 
 resource "aws_inspector2_member_association" "member" {
-  count = var.member["aws_inspector_org_managed"] ? 1 : 0
+  count = var.member["aws_inspector2_org_managed"] ? 1 : 0
   provider = aws.master
   account_id = data.aws_caller_identity.member.account_id
 }

--- a/org-member/inspector.tf
+++ b/org-member/inspector.tf
@@ -15,3 +15,11 @@ resource "aws_inspector_assessment_template" "default" {
   duration = 3600
   rules_package_arns = tolist(data.aws_inspector_rules_packages.rules.arns)
 }
+
+# AWS Inspector V2
+
+resource "aws_inspector2_member_association" "member" {
+  count = var.member["aws_inspector_org_managed"] ? 1 : 0
+  provider = aws.master
+  account_id = data.aws_caller_identity.member.account_id
+}


### PR DESCRIPTION
Makes the following changes:
- Enables AWS Inspector and configures delegated admin account.
- Adds `inspector2` service access principal.
- Adds member association resource for selective enablement.