### PR TITLE
Jm tf update provider

### DIFF
--- a/org-master/cloudtrail.tf
+++ b/org-master/cloudtrail.tf
@@ -52,17 +52,39 @@ resource "aws_iam_role_policy" "cloudtrail_log_policy" {
 resource "aws_s3_bucket" "cloudtrail-s3" {
   provider = aws.master
   bucket = "cloudtrail-${data.aws_caller_identity.master.account_id}"
-  acl = "private"
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
+  # acl = "private"
+  # server_side_encryption_configuration {
+  #   rule {
+  #     apply_server_side_encryption_by_default {
+  #       sse_algorithm = "AES256"
+  #     }
+  #   }
+  # }
   tags = {
     "website" = "false"
   }
+  # policy = templatefile("${path.module}/policies/cloudtrail-s3.json",
+  #   {
+  #     cloudtrail_s3 = "cloudtrail-${data.aws_caller_identity.master.account_id}"
+  #     account_id = data.aws_caller_identity.master.account_id
+  #     organization_id = local.aws_organization_id
+  #   }
+  # )
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "cloudtrail-s3_sse" {
+  provider = aws.master
+  bucket = aws_s3_bucket.cloudtrail-s3.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "cloudtrail-s3-policy" {
+  provider = aws.master
+  bucket = aws_s3_bucket.cloudtrail-s3.id
   policy = templatefile("${path.module}/policies/cloudtrail-s3.json",
     {
       cloudtrail_s3 = "cloudtrail-${data.aws_caller_identity.master.account_id}"

--- a/org-master/config.tf
+++ b/org-master/config.tf
@@ -3,15 +3,25 @@
 resource "aws_s3_bucket" "master_config_bucket" {
   provider = aws.master
   bucket = "aws-config-${data.aws_caller_identity.master.account_id}"
-  acl = "private"
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
+  # acl = "private"
+  # server_side_encryption_configuration {
+  #   rule {
+  #     apply_server_side_encryption_by_default {
+  #       sse_algorithm = "AES256"
+  #     }
+  #   }
+  # }
   tags = {
     "website" = "false"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "master_config_bucket_sse" {
+  provider = aws.master
+  bucket = aws_s3_bucket.master_config_bucket.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
   }
 }

--- a/org-master/policies/backup-policy.json
+++ b/org-master/policies/backup-policy.json
@@ -103,6 +103,19 @@
             }
         },
         {
+        "Action": [
+            "ec2:DeleteSnapshot",
+            "ec2:DeleteTags"
+        ],
+        "Resource": "arn:aws:ec2:*::snapshot/*",
+        "Effect": "Allow",
+        "Condition": {
+            "Null": {
+                "aws:ResourceTag/aws:backup:source-resource": "false"
+            }
+        }
+        },
+        {
             "Effect": "Allow",
             "Action": [
                 "rds:AddTagsToResource",

--- a/org-master/vpc-flowlog.tf
+++ b/org-master/vpc-flowlog.tf
@@ -6,21 +6,44 @@ data "aws_vpcs" "vpcs" {
 resource "aws_s3_bucket" "vpc_log" {
   provider = aws.master
   bucket = "flowlog-${data.aws_caller_identity.master.account_id}"
-  acl = "private"
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
+  # acl = "private"
+  # server_side_encryption_configuration {
+  #   rule {
+  #     apply_server_side_encryption_by_default {
+  #       sse_algorithm = "AES256"
+  #     }
+  #   }
+  # }
+  # lifecycle_rule {
+  #   enabled = true
+  #   expiration {
+  #     days = 90
+  #   }
+  # }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "vpc_log_sse" {
+  provider = aws.master
+  bucket = aws_s3_bucket.vpc_log.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
   }
-  lifecycle_rule {
-    enabled = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "vpc_log_lifecycle" {
+  provider = aws.master
+  bucket = aws_s3_bucket.vpc_log.id
+  rule {
+    status = "Enabled"
+    id = "expire-90-days"
     expiration {
       days = 90
     }
   }
 }
+
 
 resource "aws_s3_bucket_policy" "vpc_log" {
   provider = aws.master

--- a/org-member/cloudtrail.tf
+++ b/org-member/cloudtrail.tf
@@ -51,17 +51,37 @@ resource "aws_iam_role_policy" "cloudtrail_log_policy" {
 resource "aws_s3_bucket" "cloudtrail-s3" {
   provider = aws.member
   bucket = "cloudtrail-${data.aws_caller_identity.member.account_id}"
-  acl = "private"
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
+  # acl = "private"
+  # server_side_encryption_configuration {
+  #   rule {
+  #     apply_server_side_encryption_by_default {
+  #       sse_algorithm = "AES256"
+  #     }
+  #   }
+  # }
   tags = {
     "website" = "false"
   }
+  # policy = templatefile("${path.module}/policies/cloudtrail-s3.json",
+  #   {
+  #     cloudtrail_s3 = "cloudtrail-${data.aws_caller_identity.member.account_id}"
+  #   }
+  # )
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "cloudtrail-s3_sse" {
+  provider = aws.member
+  bucket = aws_s3_bucket.cloudtrail-s3.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "cloudtrail-s3-policy" {
+  provider = aws.member
+  bucket = aws_s3_bucket.cloudtrail-s3.id
   policy = templatefile("${path.module}/policies/cloudtrail-s3.json",
     {
       cloudtrail_s3 = "cloudtrail-${data.aws_caller_identity.member.account_id}"

--- a/org-member/config.tf
+++ b/org-member/config.tf
@@ -3,15 +3,49 @@
 resource "aws_s3_bucket" "config_bucket" {
   provider = aws.member
   bucket = "aws-config-${data.aws_caller_identity.member.account_id}"
-  acl = "private"
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
+  # acl = "private"
+  # server_side_encryption_configuration {
+  #   rule {
+  #     apply_server_side_encryption_by_default {
+  #       sse_algorithm = "AES256"
+  #     }
+  #   }
+  # }
   tags = {
     "website" = "false"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "config_bucket_sse" {
+  provider = aws.member
+  bucket = aws_s3_bucket.config_bucket.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "deny_non_https_access" {
+  bucket = aws_s3_bucket.config_bucket.id
+  policy = data.aws_iam_policy_document.deny_non_https_access.json
+  provider = aws.member
+}
+
+data "aws_iam_policy_document" "deny_non_https_access" {
+   statement {
+    sid = "Deny non-HTTPS access."
+    actions = ["s3:*"]
+    effect = "Deny"
+    resources = ["${aws_s3_bucket.config_bucket.arn}/*"]
+    principals {
+      type = "*"
+      identifiers = ["*"]
+    }
+    condition {
+      test = "Bool"
+      variable = "aws:SecureTransport"
+      values = ["false"]
+    }
   }
 }

--- a/org-member/iam.tf
+++ b/org-member/iam.tf
@@ -312,14 +312,17 @@ resource "aws_iam_group_policy" "role_dev_policy_jump" {
   count = local.bastion
   name = "dit-dev-policy"
   group = aws_iam_group.bastion_dev[0].name
-  policy = file("${path.root}/.terraform/.cache/dev_sts_policy.json")
+  # policy = data.aws_iam_policy_document.default_dev_policy_jump.json
+  # depends_on = [ data.aws_iam_policy_document.data.aws_iam_policy_document.default_dev_policy_jump ]
+  policy = file("${path.root}/policies/dev_sts_policy.json")
   depends_on = [local_file.default_dev_policy_jump]
 }
 
 data "aws_iam_policy_document" "default_dev_policy_jump" {
   provider = aws.member
   count = local.dev
-  source_json = file("${path.root}/.terraform/.cache/dev_sts_policy.json")
+  source_policy_documents = [var.dev_iam_policy]
+  # source_json = file("${path.root}/.terraform/.cache/dev_sts_policy.json")
   statement {
     sid = "${data.aws_caller_identity.member.account_id}DevAccess"
     actions = ["sts:AssumeRole"]
@@ -330,7 +333,7 @@ data "aws_iam_policy_document" "default_dev_policy_jump" {
 resource "local_file" "default_dev_policy_jump" {
   count = local.dev
   content = data.aws_iam_policy_document.default_dev_policy_jump[0].json
-  filename = "${path.root}/.terraform/.cache/dev_sts_policy.json"
+  filename = "${path.root}/policies/dev_sts_policy.json"
 }
 
 resource "aws_iam_role" "bastion_dev" {

--- a/org-member/main.tf
+++ b/org-member/main.tf
@@ -22,6 +22,8 @@ variable "soc_config" {
   default = {}
 }
 
+variable "dev_iam_policy" {}
+
 terraform {
   required_providers {
     aws = {

--- a/org-member/policies/backup-policy.json
+++ b/org-member/policies/backup-policy.json
@@ -103,6 +103,19 @@
             }
         },
         {
+            "Action"    : [
+              "ec2:DeleteSnapshot",
+              "ec2:DeleteTags"
+            ],
+            "Condition" : {
+              "Null" : {
+                "aws:ResourceTag/aws:backup:source-resource" : "false"
+                }
+              },
+            "Effect"    : "Allow",
+            "Resource"  : "arn:aws:ec2:*::snapshot/*"
+          },
+        {
             "Effect": "Allow",
             "Action": [
                 "rds:AddTagsToResource",

--- a/org-member/vpc-flowlog.tf
+++ b/org-member/vpc-flowlog.tf
@@ -6,16 +6,23 @@ data "aws_vpcs" "vpcs" {
 resource "aws_s3_bucket" "vpc_log" {
   provider = aws.member
   bucket = "flowlog-${data.aws_caller_identity.member.account_id}"
-  acl = "private"
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
+}
+resource "aws_s3_bucket_server_side_encryption_configuration" "vpc_log_sse" {
+  provider = aws.member
+  bucket = aws_s3_bucket.vpc_log.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
   }
-  lifecycle_rule {
-    enabled = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "vpc_log_lifecycle" {
+  provider = aws.member
+  bucket = aws_s3_bucket.vpc_log.id
+  rule {
+    status = "Enabled"
+    id = "expire-90-days"
     expiration {
       days = 90
     }


### PR DESCRIPTION
- Address S3 AWS deprecations. Should no longer see so many warnings.
- Address IAM AWS deprecations.
- Update IAM permissions around AWS backup. This should now work with the tag `aws:backup:source-resource`.
- Restricts connections to config S3 buckets to HTTPS only via bucket policy.