### PR TITLE
Add iam password policy

### DIFF
--- a/org-common/iam.tf
+++ b/org-common/iam.tf
@@ -103,3 +103,13 @@ data "aws_iam_policy_document" "iam_user_manager" {
     ]
   }
 }
+
+resource "aws_iam_account_password_policy" "strict" {
+  provider = aws.common
+  minimum_password_length        = var.password_policy_minimum_password_length
+  require_lowercase_characters   = var.password_policy_require_lowercase_characters
+  require_numbers                = var.password_policy_require_numbers
+  require_uppercase_characters   = var.password_policy_require_uppercase_characters
+  require_symbols                = var.password_policy_require_symbols
+  allow_users_to_change_password = var.password_policy_allow_users_to_change_password 
+}

--- a/org-common/main.tf
+++ b/org-common/main.tf
@@ -2,6 +2,28 @@ variable "org" {
   type = map(string)
 }
 
+variable "password_policy_minimum_password_length" {
+  default = 8
+}
+
+variable "password_policy_require_lowercase_characters" {
+  default = true
+}
+
+variable "password_policy_require_numbers" {
+  default = true
+}
+
+variable "password_policy_require_uppercase_characters" {
+  default = true
+}
+variable "password_policy_require_symbols" {
+  default = true
+}
+variable "password_policy_allow_users_to_change_password" {
+  default = true
+}
+
 terraform {
   required_providers {
     aws = {

--- a/org-member/iam.tf
+++ b/org-member/iam.tf
@@ -429,3 +429,13 @@ data "aws_iam_policy_document" "default_dev_policy" {
     }
   }
 }
+
+resource "aws_iam_account_password_policy" "strict" {
+  provider = aws.member
+  minimum_password_length        = 8
+  require_lowercase_characters   = true
+  require_numbers                = true
+  require_uppercase_characters   = true
+  require_symbols                = true
+  allow_users_to_change_password = true
+}

--- a/org-member/iam.tf
+++ b/org-member/iam.tf
@@ -429,13 +429,3 @@ data "aws_iam_policy_document" "default_dev_policy" {
     }
   }
 }
-
-resource "aws_iam_account_password_policy" "strict" {
-  provider = aws.member
-  minimum_password_length        = 8
-  require_lowercase_characters   = true
-  require_numbers                = true
-  require_uppercase_characters   = true
-  require_symbols                = true
-  allow_users_to_change_password = true
-}


### PR DESCRIPTION
As part of [Default password policy ticket](https://uktrade.atlassian.net/jira/software/c/projects/SR/boards/315?assignee=712020%3Ada191ff9-b219-417c-842f-ba45c011395a&selectedIssue=SR-1836)

This PR: 
- Adds default iam password policy variables to org-common to be used when creating the iam custom password policy
- Adds a iam password policy resource to org-common to create/update the password policy for each account.
- These defaults can be amended on the `terraform-aws-org` side to customise the password policy fields for the specified account. (These changes are in branch `add-iam-password-policy` on gitlabs)