### PR TITLE
Remove unused IAM role and policy

### DIFF
--- a/org-master/iam.tf
+++ b/org-master/iam.tf
@@ -129,52 +129,6 @@ resource "aws_iam_group_policy_attachment" "bastion_admin" {
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
 
-resource "aws_iam_role" "bastion_admin" {
-  provider = aws.master
-  name = "dit-admin"
-  assume_role_policy = data.aws_iam_policy_document.bastion_sts_admin.json
-  max_session_duration = 43200
-  permissions_boundary = aws_iam_policy.default_admin.arn
-}
-
-data "aws_iam_policy_document" "bastion_sts_admin" {
-  provider = aws.master
-  statement {
-    sid = "TrustBastionAccount"
-    actions = ["sts:AssumeRole"]
-    principals {
-      type = "AWS"
-      identifiers = ["arn:aws:iam::${var.org["bastion_account"]}:root"]
-    }
-    condition {
-      test = "StringEquals"
-      variable = "aws:PrincipalOrgID"
-      values = [local.aws_organization_id]
-    }
-    condition {
-      test = "Bool"
-      variable = "aws:MultiFactorAuthPresent"
-      values = ["true"]
-    }
-    condition {
-      test = "Null"
-      variable = "aws:TokenIssueTime"
-      values = ["false"]
-    }
-    condition {
-      test = "Bool"
-      variable = "aws:SecureTransport"
-      values = ["true"]
-    }
-  }
-}
-
-resource "aws_iam_role_policy_attachment" "bastion_admin" {
-  provider = aws.master
-  role = aws_iam_role.bastion_admin.name
-  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
-}
-
 # Sentinel
 
 resource "aws_iam_role" "sentinel_role" {

--- a/org-master/iam.tf
+++ b/org-master/iam.tf
@@ -5,61 +5,6 @@ resource "aws_iam_policy" "default_policy" {
   policy = file("${path.module}/policies/default-boundary-policy.json")
 }
 
-resource "aws_iam_policy" "default_admin" {
-  provider = aws.master
-  name = "dit-default-admin"
-  policy = data.aws_iam_policy_document.default_admin.json
-}
-
-data "aws_iam_policy_document" "default_admin" {
-  provider = aws.master
-  statement {
-    actions = ["*"]
-    resources = ["*"]
-  }
-  statement {
-    sid = "EnableServicesForUSRegion"
-    actions = [
-      "acm:*",
-      "config:*"
-    ]
-    resources = ["*"]
-    condition {
-      test = "StringEquals"
-      variable = "aws:RequestedRegion"
-      values = ["eu-west-1", "eu-west-2", "us-east-1"]
-    }
-  }
-  statement {
-    sid = "DisableOtherRegions"
-    effect = "Deny"
-    not_actions = [
-      "aws-portal:*",
-      "account:*",
-      "billing:*",
-      "billingconductor:*",
-      "budgets:*",
-      "ce:*",
-      "consolidatedbilling:*",
-      "cur:*",
-      "freetier:*",
-      "invoicing:*",
-      "payments:*",
-      "tax:*",
-      "iam:*",
-      "organizations:*",
-      "support:*",
-      "sts:*"
-    ]
-    resources = ["*"]
-    condition {
-      test = "StringNotEquals"
-      variable = "aws:RequestedRegion"
-      values = ["eu-west-1", "eu-west-2", "us-east-1"]
-    }
-  }
-}
-
 resource "aws_iam_group" "bastion_readonly" {
   provider = aws.master
   name = "readonly"

--- a/org-member/iam.tf
+++ b/org-member/iam.tf
@@ -5,66 +5,6 @@ resource "aws_iam_policy" "default_policy" {
   policy = file("${path.module}/policies/default-boundary-policy.json")
 }
 
-resource "aws_iam_policy" "default_admin" {
-  provider = aws.member
-  name = "dit-default-admin"
-  policy = data.aws_iam_policy_document.default_admin.json
-}
-
-data "aws_iam_policy_document" "default_admin" {
-  provider = aws.member
-  statement {
-    actions = ["*"]
-    resources = ["*"]
-  }
-  statement {
-    sid = "EnableServicesForUSRegion"
-    actions = [
-      "acm:*",
-      "config:*"
-    ]
-    resources = ["*"]
-    condition {
-      test = "StringEquals"
-      variable = "aws:RequestedRegion"
-      values = ["eu-west-1", "eu-west-2", "us-east-1"]
-    }
-  }
-  statement {
-    sid = "DisableOtherRegions"
-    effect = "Deny"
-    not_actions = [
-      "account:Get*",
-      "billing:Get*",
-      "billing:List*",
-      "ce:Describe*",
-      "ce:Get*",
-      "ce:List*",
-      "consolidatedbilling:Get*",
-      "consolidatedbilling:List*",
-      "cur:Get*",
-      "cur:Validate*",
-      "freetier:Get*",
-      "invoicing:Get*",
-      "invoicing:List*",
-      "payments:Get*",
-      "payments:List*",
-      "tax:Get*",
-      "tax:List*",
-      "iam:*",
-      "organizations:*",
-      "support:*",
-      "sts:*"
-    ]
-    resources = ["*"]
-    condition {
-      test = "StringNotEquals"
-      variable = "aws:RequestedRegion"
-      values = ["eu-west-1", "eu-west-2"]
-    }
-  }
-}
-
 resource "aws_iam_policy" "default_dev" {
   provider = aws.member
   name = "dit-default-dev"

--- a/org-member/iam.tf
+++ b/org-member/iam.tf
@@ -241,52 +241,6 @@ resource "aws_iam_group_policy_attachment" "bastion_admin" {
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
 
-resource "aws_iam_role" "bastion_admin" {
-  provider = aws.member
-  name = "dit-admin"
-  assume_role_policy = data.aws_iam_policy_document.bastion_sts_admin.json
-  max_session_duration = 43200
-  permissions_boundary = aws_iam_policy.default_admin.arn
-}
-
-data "aws_iam_policy_document" "bastion_sts_admin" {
-  provider = aws.member
-  statement {
-    sid = "TrustBastionAccount"
-    actions = ["sts:AssumeRole"]
-    principals {
-      type = "AWS"
-      identifiers = ["arn:aws:iam::${var.org["bastion_account"]}:root"]
-    }
-    condition {
-      test = "StringEquals"
-      variable = "aws:PrincipalOrgID"
-      values = [local.aws_organization_id]
-    }
-    condition {
-      test = "Bool"
-      variable = "aws:MultiFactorAuthPresent"
-      values = ["true"]
-    }
-    condition {
-      test = "Null"
-      variable = "aws:TokenIssueTime"
-      values = ["false"]
-    }
-    condition {
-      test = "Bool"
-      variable = "aws:SecureTransport"
-      values = ["true"]
-    }
-  }
-}
-
-resource "aws_iam_role_policy_attachment" "bastion_admin" {
-  provider = aws.member
-  role = aws_iam_role.bastion_admin.name
-  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
-}
-
 locals {
   dev = var.member["dev_access"] == "true" ? 1 : 0
   bastion = data.aws_caller_identity.member.account_id == var.org["bastion_account"] ? 1 : 0


### PR DESCRIPTION
Makes the following changes:
- Removes the `dit-admin` role from master and member accounts.
- Also removes the `dit-default-admin` policy from master and member accounts.