### PR TITLE
remove lifecycle policy to ignore the policy changes.

### DIFF
--- a/org-master/s3.tf
+++ b/org-master/s3.tf
@@ -312,9 +312,9 @@ resource "aws_s3_bucket_policy" "sentinel_vpc_flowlog_bucket_account_access" {
   provider = aws.master
   bucket   = aws_s3_bucket.sentinel_vpc_flowlog_bucket.id
   policy   = data.aws_iam_policy_document.sentinel_vpc_flowlog_bucket_account_access.json
-  lifecycle {
-    ignore_changes = [ policy ]
-  }
+  # lifecycle {
+  #   ignore_changes = [ policy ]
+  # }
 }
 
 data "aws_organizations_organization" "master" {

--- a/org-master/s3.tf
+++ b/org-master/s3.tf
@@ -312,9 +312,6 @@ resource "aws_s3_bucket_policy" "sentinel_vpc_flowlog_bucket_account_access" {
   provider = aws.master
   bucket   = aws_s3_bucket.sentinel_vpc_flowlog_bucket.id
   policy   = data.aws_iam_policy_document.sentinel_vpc_flowlog_bucket_account_access.json
-  # lifecycle {
-  #   ignore_changes = [ policy ]
-  # }
 }
 
 data "aws_organizations_organization" "master" {


### PR DESCRIPTION
commented out the lifecycle policy in resource aws_s3_bucket_policy.sentinel_vpc_flowlog_bucket_account_access as this ignored new accounts being changed.