### PR TITLE
S3 Public Access Block

### DIFF
--- a/new-org-member/main.tf
+++ b/new-org-member/main.tf
@@ -4,7 +4,7 @@ variable "org" {
 }
 
 variable "member" {
-  type = map(string)
+  type = any
   default = {}
 }
 

--- a/org-common/main.tf
+++ b/org-common/main.tf
@@ -1,5 +1,5 @@
 variable "org" {
-  type = map(string)
+  type = any
 }
 
 variable "password_policy_minimum_password_length" {

--- a/org-master/cloudtrail.tf
+++ b/org-master/cloudtrail.tf
@@ -72,6 +72,15 @@ resource "aws_s3_bucket" "cloudtrail-s3" {
   # )
 }
 
+resource "aws_s3_bucket_public_access_block" "cloudtrail-s3_block_public_access" {
+  provider = aws.master
+  bucket = aws_s3_bucket.cloudtrail-s3.id
+  block_public_acls = true
+  block_public_policy = true
+  ignore_public_acls = true
+  restrict_public_buckets = true
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "cloudtrail-s3_sse" {
   provider = aws.master
   bucket = aws_s3_bucket.cloudtrail-s3.id

--- a/org-master/config.tf
+++ b/org-master/config.tf
@@ -3,14 +3,6 @@
 resource "aws_s3_bucket" "master_config_bucket" {
   provider = aws.master
   bucket = "aws-config-${data.aws_caller_identity.master.account_id}"
-  # acl = "private"
-  # server_side_encryption_configuration {
-  #   rule {
-  #     apply_server_side_encryption_by_default {
-  #       sse_algorithm = "AES256"
-  #     }
-  #   }
-  # }
   tags = {
     "website" = "false"
   }

--- a/org-master/config.tf
+++ b/org-master/config.tf
@@ -16,6 +16,15 @@ resource "aws_s3_bucket" "master_config_bucket" {
   }
 }
 
+resource "aws_s3_bucket_public_access_block" "config_bucket_block_public_access" {
+  provider = aws.master
+  bucket = aws_s3_bucket.master_config_bucket.id
+  block_public_acls = true
+  block_public_policy = true
+  ignore_public_acls = true
+  restrict_public_buckets = true
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "master_config_bucket_sse" {
   provider = aws.master
   bucket = aws_s3_bucket.master_config_bucket.id

--- a/org-master/main.tf
+++ b/org-master/main.tf
@@ -1,5 +1,5 @@
 variable "org" {
-  type = map(string)
+  type = any
   default = {
     "aws_shared_credentials_file" = "~/.aws/credentials"
     "aws_profile" = "default"

--- a/org-master/s3.tf
+++ b/org-master/s3.tf
@@ -1,27 +1,9 @@
 resource "aws_s3_bucket" "sentinel_logs" {
   provider = aws.master
   bucket   = "${var.soc_config["sentinel_s3_bucket_name"]}-${data.aws_caller_identity.master.account_id}"
-  # acl      = "private"
   tags     = tomap(local.sentinel_common_resource_tag)
-
-  # lifecycle_rule {
-  #   id      = "sentinel_log_expiry"
-  #   enabled = true
-  #   expiration {
-  #     days = local.sentinel_log_expiry_days
-  #   }
-  # }
-
-  # server_side_encryption_configuration {
-  #   rule {
-  #     bucket_key_enabled = false
-  #     apply_server_side_encryption_by_default {
-  #       sse_algorithm = "AES256"
-  #     }
-  #   }
-  # }
-
 }
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "sentinel_logs_sse" {
   provider = aws.master
   bucket = aws_s3_bucket.sentinel_logs.id
@@ -31,6 +13,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "sentinel_logs_sse
     }
   }
 }
+
 resource "aws_s3_bucket_lifecycle_configuration" "sentinel_logs_lifecycle" {
   provider = aws.master
   bucket = aws_s3_bucket.sentinel_logs.id

--- a/org-master/s3.tf
+++ b/org-master/s3.tf
@@ -1,3 +1,11 @@
+resource "aws_s3_account_public_access_block" "master_s3_public_access" {
+  provider = aws.master
+  block_public_acls       = try (var.org.account_public_access_block.block_public_acls, true)
+  block_public_policy     = try (var.org.account_public_access_block.block_public_policy, true)
+  ignore_public_acls      = try (var.org.account_public_access_block.ignore_public_acls, true)
+  restrict_public_buckets = try (var.org.account_public_access_block.restrict_public_buckets, true)
+}
+
 resource "aws_s3_bucket" "sentinel_logs" {
   provider = aws.master
   bucket   = "${var.soc_config["sentinel_s3_bucket_name"]}-${data.aws_caller_identity.master.account_id}"

--- a/org-master/vpc-flowlog.tf
+++ b/org-master/vpc-flowlog.tf
@@ -22,6 +22,15 @@ resource "aws_s3_bucket" "vpc_log" {
   # }
 }
 
+resource "aws_s3_bucket_public_access_block" "vpc_log_block_public_access" {
+  provider = aws.master
+  bucket = aws_s3_bucket.vpc_log.id
+  block_public_acls = true
+  block_public_policy = true
+  ignore_public_acls = true
+  restrict_public_buckets = true
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "vpc_log_sse" {
   provider = aws.master
   bucket = aws_s3_bucket.vpc_log.id

--- a/org-master/vpc-flowlog.tf
+++ b/org-master/vpc-flowlog.tf
@@ -6,20 +6,6 @@ data "aws_vpcs" "vpcs" {
 resource "aws_s3_bucket" "vpc_log" {
   provider = aws.master
   bucket = "flowlog-${data.aws_caller_identity.master.account_id}"
-  # acl = "private"
-  # server_side_encryption_configuration {
-  #   rule {
-  #     apply_server_side_encryption_by_default {
-  #       sse_algorithm = "AES256"
-  #     }
-  #   }
-  # }
-  # lifecycle_rule {
-  #   enabled = true
-  #   expiration {
-  #     days = 90
-  #   }
-  # }
 }
 
 resource "aws_s3_bucket_public_access_block" "vpc_log_block_public_access" {

--- a/org-member/cloudtrail.tf
+++ b/org-member/cloudtrail.tf
@@ -51,22 +51,9 @@ resource "aws_iam_role_policy" "cloudtrail_log_policy" {
 resource "aws_s3_bucket" "cloudtrail-s3" {
   provider = aws.member
   bucket = "cloudtrail-${data.aws_caller_identity.member.account_id}"
-  # acl = "private"
-  # server_side_encryption_configuration {
-  #   rule {
-  #     apply_server_side_encryption_by_default {
-  #       sse_algorithm = "AES256"
-  #     }
-  #   }
-  # }
   tags = {
     "website" = "false"
   }
-  # policy = templatefile("${path.module}/policies/cloudtrail-s3.json",
-  #   {
-  #     cloudtrail_s3 = "cloudtrail-${data.aws_caller_identity.member.account_id}"
-  #   }
-  # )
 }
 
 resource "aws_s3_bucket_public_access_block" "cloudtrail-s3_block_public_access" {

--- a/org-member/cloudtrail.tf
+++ b/org-member/cloudtrail.tf
@@ -69,6 +69,15 @@ resource "aws_s3_bucket" "cloudtrail-s3" {
   # )
 }
 
+resource "aws_s3_bucket_public_access_block" "cloudtrail-s3_block_public_access" {
+  provider = aws.member
+  bucket = aws_s3_bucket.cloudtrail-s3.id
+  block_public_acls = true
+  block_public_policy = true
+  ignore_public_acls = true
+  restrict_public_buckets = true
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "cloudtrail-s3_sse" {
   provider = aws.member
   bucket = aws_s3_bucket.cloudtrail-s3.id

--- a/org-member/config.tf
+++ b/org-member/config.tf
@@ -16,6 +16,15 @@ resource "aws_s3_bucket" "config_bucket" {
   }
 }
 
+resource "aws_s3_bucket_public_access_block" "config_bucket_block_public_access" {
+  provider = aws.member
+  bucket = aws_s3_bucket.config_bucket.id
+  block_public_acls = true
+  block_public_policy = true
+  ignore_public_acls = true
+  restrict_public_buckets = true
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "config_bucket_sse" {
   provider = aws.member
   bucket = aws_s3_bucket.config_bucket.id

--- a/org-member/config.tf
+++ b/org-member/config.tf
@@ -3,14 +3,6 @@
 resource "aws_s3_bucket" "config_bucket" {
   provider = aws.member
   bucket = "aws-config-${data.aws_caller_identity.member.account_id}"
-  # acl = "private"
-  # server_side_encryption_configuration {
-  #   rule {
-  #     apply_server_side_encryption_by_default {
-  #       sse_algorithm = "AES256"
-  #     }
-  #   }
-  # }
   tags = {
     "website" = "false"
   }

--- a/org-member/main.tf
+++ b/org-member/main.tf
@@ -8,7 +8,7 @@ variable "org" {
 }
 
 variable "member" {
-  type = map(string)
+  type = any
   default = {
     "aws_shared_credentials_file" = "~/.aws/credentials"
     "aws_profile" = "default"

--- a/org-member/s3.tf
+++ b/org-member/s3.tf
@@ -1,0 +1,7 @@
+resource "aws_s3_account_public_access_block" "member_s3_public_access" {
+  provider = aws.member
+  block_public_acls       = try (var.member.account_public_access_block.block_public_acls, true)
+  block_public_policy     = try (var.member.account_public_access_block.block_public_policy, true)
+  ignore_public_acls      = try (var.member.account_public_access_block.ignore_public_acls, true)
+  restrict_public_buckets = try (var.member.account_public_access_block.restrict_public_buckets, true)
+}

--- a/org-member/vpc-flowlog.tf
+++ b/org-member/vpc-flowlog.tf
@@ -7,6 +7,16 @@ resource "aws_s3_bucket" "vpc_log" {
   provider = aws.member
   bucket = "flowlog-${data.aws_caller_identity.member.account_id}"
 }
+
+resource "aws_s3_bucket_public_access_block" "vpc_log_block_public_access" {
+  provider = aws.member
+  bucket = aws_s3_bucket.vpc_log.id
+  block_public_acls = true
+  block_public_policy = true
+  ignore_public_acls = true
+  restrict_public_buckets = true
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "vpc_log_sse" {
   provider = aws.member
   bucket = aws_s3_bucket.vpc_log.id

--- a/soc-integration/main.tf
+++ b/soc-integration/main.tf
@@ -4,7 +4,7 @@ variable "config" {
 }
 
 variable "member" {
-  type = map(string)
+  type = any
   default = {}
 }
 


### PR DESCRIPTION
Makes the following changes:
- Update the account variable to `any` type to allow maps of multiple types (including maps).
- Add public_access_block defaults for the AWS account.
- Add public_access_block settings for 3 buckets:
  - AWS Config
  - VPC Flowlog
  - CloudTrail
- Removes some previously commented-out args (deprecated bucket encryption args).