### PR TITLE
Move dev sts policy local file location

### DIFF
--- a/org-member/iam.tf
+++ b/org-member/iam.tf
@@ -208,7 +208,7 @@ resource "aws_iam_group_policy" "role_dev_policy_jump" {
   group    = aws_iam_group.bastion_dev[0].name
   # policy = data.aws_iam_policy_document.default_dev_policy_jump.json
   # depends_on = [ data.aws_iam_policy_document.data.aws_iam_policy_document.default_dev_policy_jump ]
-  policy     = file("${path.root}/../policies/dev_sts_policy.json")
+  policy     = file("${path.root}/../../policies/dev_sts_policy.json")
   # depends_on = [local_file.default_dev_policy_jump]
 }
 

--- a/org-member/iam.tf
+++ b/org-member/iam.tf
@@ -208,8 +208,8 @@ resource "aws_iam_group_policy" "role_dev_policy_jump" {
   group    = aws_iam_group.bastion_dev[0].name
   # policy = data.aws_iam_policy_document.default_dev_policy_jump.json
   # depends_on = [ data.aws_iam_policy_document.data.aws_iam_policy_document.default_dev_policy_jump ]
-  policy     = file("${path.root}/policies/dev_sts_policy.json")
-  depends_on = [local_file.default_dev_policy_jump]
+  policy     = file("${path.root}/../policies/dev_sts_policy.json")
+  # depends_on = [local_file.default_dev_policy_jump]
 }
 
 data "aws_iam_policy_document" "default_dev_policy_jump" {
@@ -224,11 +224,11 @@ data "aws_iam_policy_document" "default_dev_policy_jump" {
   }
 }
 
-resource "local_file" "default_dev_policy_jump" {
-  count    = local.dev
-  content  = data.aws_iam_policy_document.default_dev_policy_jump[0].json
-  filename = "${path.root}/policies/dev_sts_policy.json"
-}
+# resource "local_file" "default_dev_policy_jump" {
+#   count    = local.dev
+#   content  = data.aws_iam_policy_document.default_dev_policy_jump[0].json
+#   filename = "${path.root}/policies/dev_sts_policy.json"
+# }
 
 resource "aws_iam_role" "bastion_dev" {
   provider             = aws.member


### PR DESCRIPTION
As part of work for [Scalability - split out the state files across Production DBT PaaS ticket](https://uktrade.atlassian.net/jira/software/c/projects/SR/boards/315?assignee=712020%3Ada191ff9-b219-417c-842f-ba45c011395a&selectedIssue=SR-2015)

This PR updated the local file path for the dev_sts_policy file as the new directory structure will have the module calling from 2 directories deep form the root of the project where the policies folder is located. 

Example: 
module.dev has been moved from the root directory to `env/Dev/member-dev.tf` so to find the old policy folder will need to look up 2 levels in the directory structure. 