### PR TITLE
Log groups are now created when specified

### DIFF
--- a/org-member/loggroups.tf
+++ b/org-member/loggroups.tf
@@ -4,51 +4,51 @@
 # e.g. if var.member.createloggroups == true, set count to 1 and create the resource. 
 
 resource "aws_iam_role" "CWLtoSubscriptionFilterRole" {
-  count = try(var.member.createloggroups == true ? 1 : 0, 0)
-  name = "CWLtoSubscriptionFilterRole"
+  count    = try(var.member.createloggroups == true ? 1 : 0, 0)
+  name     = "CWLtoSubscriptionFilterRole"
   provider = aws.member
 
   assume_role_policy = jsonencode({
-  Version   = "2008-10-17"
-  "Statement": {
-      "Effect": "Allow",
-      "Principal": { "Service": "logs.amazonaws.com" },
-      "Action": "sts:AssumeRole"
+    Version = "2008-10-17"
+    "Statement" : {
+      "Effect" : "Allow",
+      "Principal" : { "Service" : "logs.amazonaws.com" },
+      "Action" : "sts:AssumeRole"
     }
-})
+  })
 }
 
 resource "aws_iam_policy" "Permissions-Policy-For-CWL-Subscription-filter" {
-  count = try(var.member.createloggroups == true ? 1 : 0, 0)
-  name = "Permissions-Policy-For-CWL-Subscription-filter"
+  count    = try(var.member.createloggroups == true ? 1 : 0, 0)
+  name     = "Permissions-Policy-For-CWL-Subscription-filter"
   provider = aws.member
-  path = "/"
-  policy = jsonencode({ 
-  Version = "2012-10-17"
-  "Statement": [
-      { 
-          "Effect": "Allow", 
-          "Action": "logs:PutLogEvents", 
-          "Resource": "arn:aws:logs:eu-west-2:${data.aws_caller_identity.member.account_id}:log-group:*:*" 
-      } 
-  ] 
-})
+  path     = "/"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : "logs:PutLogEvents",
+        "Resource" : "arn:aws:logs:eu-west-2:${data.aws_caller_identity.member.account_id}:log-group:*:*"
+      }
+    ]
+  })
 }
 
 resource "aws_iam_role_policy_attachment" "Permissions-Policy-For-CWL-Subscription-filter" {
-  count = try(var.member.createloggroups == true ? 1 : 0, 0)
-  provider = aws.member
+  count      = try(var.member.createloggroups == true ? 1 : 0, 0)
+  provider   = aws.member
   role       = aws_iam_role.CWLtoSubscriptionFilterRole[0].name
   policy_arn = aws_iam_policy.Permissions-Policy-For-CWL-Subscription-filter[0].arn
 }
 
 resource "aws_ssm_parameter" "central_log_groups" {
-  count = try(var.member.createloggroups == true ? 1 : 0, 0)
+  count    = try(var.member.createloggroups == true ? 1 : 0, 0)
   provider = aws.member
-  name  = "/copilot/tools/central_log_groups"
-  type  = "String"
+  name     = "/copilot/tools/central_log_groups"
+  type     = "String"
   value = jsonencode({
-    "prod": "arn:aws:logs:eu-west-2:${data.aws_caller_identity.logarchive.account_id}:destination:cwl_log_destination", 
-    "dev": "arn:aws:logs:eu-west-2:${data.aws_caller_identity.logarchive.account_id}:destination:cwl_log_destination"
+    "prod" : "arn:aws:logs:eu-west-2:${data.aws_caller_identity.logarchive.account_id}:destination:cwl_log_destination",
+    "dev" : "arn:aws:logs:eu-west-2:${data.aws_caller_identity.logarchive.account_id}:destination:cwl_log_destination"
   })
 }

--- a/org-member/loggroups.tf
+++ b/org-member/loggroups.tf
@@ -1,0 +1,54 @@
+# Create log groups for accounts.
+# At time of writing (29th Feb 2024) I wasn't sure if we wanted to roll this out to all accounts.
+# So I've added in a 'count' to act as an if statement. 
+# e.g. if var.member.createloggroups == true, set count to 1 and create the resource. 
+
+resource "aws_iam_role" "CWLtoSubscriptionFilterRole" {
+  count = try(var.member.createloggroups == true ? 1 : 0, 0)
+  name = "CWLtoSubscriptionFilterRole"
+  provider = aws.member
+
+  assume_role_policy = jsonencode({
+  Version   = "2008-10-17"
+  "Statement": {
+      "Effect": "Allow",
+      "Principal": { "Service": "logs.amazonaws.com" },
+      "Action": "sts:AssumeRole"
+    }
+})
+}
+
+resource "aws_iam_policy" "Permissions-Policy-For-CWL-Subscription-filter" {
+  count = try(var.member.createloggroups == true ? 1 : 0, 0)
+  name = "Permissions-Policy-For-CWL-Subscription-filter"
+  provider = aws.member
+  path = "/"
+  policy = jsonencode({ 
+  Version = "2012-10-17"
+  "Statement": [
+      { 
+          "Effect": "Allow", 
+          "Action": "logs:PutLogEvents", 
+          "Resource": "arn:aws:logs:eu-west-2:${data.aws_caller_identity.member.account_id}:log-group:*:*" 
+      } 
+  ] 
+})
+}
+
+resource "aws_iam_role_policy_attachment" "Permissions-Policy-For-CWL-Subscription-filter" {
+  count = try(var.member.createloggroups == true ? 1 : 0, 0)
+  provider = aws.member
+  role       = aws_iam_role.CWLtoSubscriptionFilterRole[0].name
+  policy_arn = aws_iam_policy.Permissions-Policy-For-CWL-Subscription-filter[0].arn
+}
+
+resource "aws_ssm_parameter" "central_log_groups" {
+  count = try(var.member.createloggroups == true ? 1 : 0, 0)
+  provider = aws.member
+  name  = "/copilot/tools/central_log_groups"
+  type  = "String"
+  value = jsonencode({
+    "prod": "arn:aws:logs:eu-west-2:${data.aws_caller_identity.logarchive.account_id}:destination:cwl_log_destination", 
+    "dev": "arn:aws:logs:eu-west-2:${data.aws_caller_identity.logarchive.account_id}:destination:cwl_log_destination"
+  })
+}

--- a/org-member/loggroups.tf
+++ b/org-member/loggroups.tf
@@ -4,9 +4,9 @@
 # e.g. if var.member.createloggroups == true, set count to 1 and create the resource. 
 
 resource "aws_iam_role" "CWLtoSubscriptionFilterRole" {
+  provider = aws.member
   count    = try(var.member.createloggroups == true ? 1 : 0, 0)
   name     = "CWLtoSubscriptionFilterRole"
-  provider = aws.member
 
   assume_role_policy = jsonencode({
     Version = "2008-10-17"
@@ -19,9 +19,9 @@ resource "aws_iam_role" "CWLtoSubscriptionFilterRole" {
 }
 
 resource "aws_iam_policy" "Permissions-Policy-For-CWL-Subscription-filter" {
+  provider = aws.member
   count    = try(var.member.createloggroups == true ? 1 : 0, 0)
   name     = "Permissions-Policy-For-CWL-Subscription-filter"
-  provider = aws.member
   path     = "/"
   policy = jsonencode({
     Version = "2012-10-17"
@@ -36,15 +36,15 @@ resource "aws_iam_policy" "Permissions-Policy-For-CWL-Subscription-filter" {
 }
 
 resource "aws_iam_role_policy_attachment" "Permissions-Policy-For-CWL-Subscription-filter" {
-  count      = try(var.member.createloggroups == true ? 1 : 0, 0)
   provider   = aws.member
+  count      = try(var.member.createloggroups == true ? 1 : 0, 0)
   role       = aws_iam_role.CWLtoSubscriptionFilterRole[0].name
   policy_arn = aws_iam_policy.Permissions-Policy-For-CWL-Subscription-filter[0].arn
 }
 
 resource "aws_ssm_parameter" "central_log_groups" {
-  count    = try(var.member.createloggroups == true ? 1 : 0, 0)
   provider = aws.member
+  count    = try(var.member.createloggroups == true ? 1 : 0, 0)
   name     = "/copilot/tools/central_log_groups"
   type     = "String"
   value = jsonencode({

--- a/org-member/main.tf
+++ b/org-member/main.tf
@@ -28,7 +28,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      configuration_aliases = [aws.master, aws.member]
+      configuration_aliases = [aws.master, aws.member, aws.logarchive]
     }
   }
 }
@@ -51,6 +51,9 @@ data "aws_caller_identity" "master" {
 
 data "aws_caller_identity" "member" {
   provider = aws.member
+}
+data "aws_caller_identity" "logarchive" {
+  provider = aws.logarchive
 }
 
 variable "aws_regions" {


### PR DESCRIPTION
Related to SR-2259.

New log groups file creates log groups when it's in var.member. This allows us to specify which aws accounts should get log groups easier in terraform going forward.