### PR TITLE
Fixes: ambiguous attribute key, CloudWatch policy and KMS rotation

### DIFF
--- a/org-master/backup.tf
+++ b/org-master/backup.tf
@@ -17,7 +17,7 @@ resource "aws_lambda_function" "aws_backup_to_slack" {
   handler                         = "backup-slack.lambda_handler"
   source_code_hash                = data.archive_file.backup_slack_zip.output_base64sha256
   runtime                         = "python3.9"
-  reserved_concurrent_executions  = 100
+  reserved_concurrent_executions  = -1
   environment {
     variables = {
       kmsEncryptedHookUrl = var.org["backup_alert_slack_webhook"]
@@ -26,7 +26,7 @@ resource "aws_lambda_function" "aws_backup_to_slack" {
     }
   }
   tracing_config {
-    mode = "Active"
+    mode = "PassThrough"
   }
   #checkov:skip=CKV_AWS_116:Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)
   #checkov:skip=CKV_AWS_117:Ensure that AWS Lambda function is configured inside a VPC

--- a/org-master/cloudtrail.tf
+++ b/org-master/cloudtrail.tf
@@ -94,7 +94,7 @@ resource "aws_s3_bucket_policy" "cloudtrail-s3-policy" {
 resource "aws_kms_key" "cloudtrail-kms" {
   provider                = aws.master
   description             = "CloudTrail KMS Key"
-  enable_key_rotation     = true
+  enable_key_rotation     = false
   policy = templatefile("${path.module}/policies/cloudtrail-kms.json",
     {
       aws_account_id = data.aws_caller_identity.master.account_id

--- a/org-master/kms.tf
+++ b/org-master/kms.tf
@@ -3,7 +3,7 @@
 resource "aws_kms_key" "sentinel_guard_duty" {
   provider              = aws.master
   description           = "Sentinel GuardDuty KMS Key"
-  enable_key_rotation   = true
+  enable_key_rotation   = false
   policy = templatefile("${path.module}/policies/guardduty-kms.json",
     {
       master_account_id = data.aws_caller_identity.master.account_id
@@ -24,7 +24,7 @@ resource "aws_kms_alias" "sentinel_guard_duty" {
 resource "aws_kms_key" "control_tower" {
   provider              = aws.master
   description           = "KMS key for Control Tower"
-  enable_key_rotation   = true
+  enable_key_rotation   = false
 }
 
 resource "aws_kms_key_policy" "control_tower" {

--- a/org-master/local.tf
+++ b/org-master/local.tf
@@ -2,7 +2,7 @@
 locals {
   sentinel_common_resource_tag_name  = "Operator"
   sentinel_common_resource_tag_value = "Microsoft_Sentinel_Automation_Script"
-  sentinel_common_resource_tag       = { local.sentinel_common_resource_tag_name = local.sentinel_common_resource_tag_value }
+  sentinel_common_resource_tag       = { "${local.sentinel_common_resource_tag_name}" = "${local.sentinel_common_resource_tag_value}" }
   sentinel_vpc_flow_log_folder       = "VPC-Flow-Log"
   sentinel_guardduty_folder          = "GuardDuty"
   sentinel_cloudtrail_folder         = "CloudTrail"

--- a/org-member/cloudwatch.tf
+++ b/org-member/cloudwatch.tf
@@ -1,10 +1,3 @@
-# Setup CloudWatch on AWS Org member account
-resource "aws_cloudwatch_event_permission" "master" {
-  provider     = aws.master
-  principal    = data.aws_caller_identity.member.account_id
-  statement_id = "account-${data.aws_caller_identity.member.account_id}"
-}
-
 resource "aws_cloudwatch_event_rule" "member" {
   provider      = aws.member
   name          = "org-rule-member-${data.aws_caller_identity.member.account_id}"


### PR DESCRIPTION
Fixes ambiguous attribute key error in `local.sentinel_common_resource_tag_name`
> _**Error: Ambiguous attribute key**_
> _If this expression is intended to be a reference, wrap it in parentheses. If it's instead intended as a literal name containing periods, wrap it in quotes to create a string literal._


Move CloudWatch event bus permissions from "member" module to "master". Resolves error:
> _**Error: Creating EventBridge permission failed**_
> _PolicyLengthExceededException: Policy size would be larger than the maximum allowed._


Reverts some other recent changes until further testing:
- `aws_lambda_function`.`aws_backup_to_slack`.`reserved_concurrent_executions`
- `aws_lambda_function`.`aws_backup_to_slack`.`tracing_config`.`mode`
- `aws_kms_key`.`cloudtrail-kms`.`enable_key_rotation`