### PR TITLE
Add license management to Organisation as a service

### DIFF
--- a/org-master/org.tf
+++ b/org-master/org.tf
@@ -16,7 +16,8 @@ resource "aws_organizations_organization" "org" {
     "controltower.amazonaws.com",
     "inspector2.amazonaws.com",
     "member.org.stacksets.cloudformation.amazonaws.com",
-    "health.amazonaws.com"
+    "health.amazonaws.com",
+    "license-management.marketplace.amazonaws.com"
   ]
   enabled_policy_types = [
     "BACKUP_POLICY",


### PR DESCRIPTION
# Description

- Enable License Management in organisation Terraform

## Contributors

@shehzadashiq 

## Type of change

- [] Refactoring (made code better without changing its behaviour)
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Applied recommended checks and exceptions

## How this has been tested

Ran `terraform init` and `terraform plan` against an existing account which had been created and no destructive changes were made.

Without the proposed changes the license management service will be removed.

With the service added, the infrastructure matches the configuration and the license management service is not removed.

<img width="890" alt="image" src="https://github.com/uktrade/terraform-module-aws_account/assets/5746804/f0d38977-800a-4558-a2e0-8b37185169f0">

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
