### PR TITLE
Add CloudWatch account-wide data protection policy for all accounts

### DIFF
--- a/org-common/logs.tf
+++ b/org-common/logs.tf
@@ -30,7 +30,8 @@ resource "aws_cloudformation_stack" "account_wide_logs_data_protection_policy" {
               {
                 Sid = "audit-policy"
                 DataIdentifier = [
-                  "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
+                  "arn:aws:dataprotection::aws:data-identifier/AwsSecretKey",
+                  "arn:aws:dataprotection::aws:data-identifier/OpenSshPrivateKey",
                   "Password",
                   "SecretKey"
                 ]
@@ -43,7 +44,8 @@ resource "aws_cloudformation_stack" "account_wide_logs_data_protection_policy" {
               {
                 Sid = "redact-policy"
                 DataIdentifier = [
-                  "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
+                  "arn:aws:dataprotection::aws:data-identifier/AwsSecretKey",
+                  "arn:aws:dataprotection::aws:data-identifier/OpenSshPrivateKey",
                   "Password",
                   "SecretKey"
                 ]

--- a/org-common/logs.tf
+++ b/org-common/logs.tf
@@ -1,0 +1,62 @@
+resource "aws_cloudformation_stack" "account_wide_logs_data_protection_policy" {
+  provider = aws.common
+  name     = "AccountWideDataProtectionLogsPolicy"
+
+  template_body = jsonencode({
+    Resources = {
+      AccountPolicy = {
+        Type = "AWS::Logs::AccountPolicy"
+        Properties = {
+          PolicyName = "AccountWideDataProtectionLogsPolicy"
+          PolicyType = "DATA_PROTECTION_POLICY"
+          Scope      = "ALL"
+          PolicyDocument = jsonencode({
+            Name        = "ACCOUNT_DATA_PROTECTION_POLICY"
+            Description = ""
+            Version     = "2021-06-01"
+            Configuration = {
+              CustomDataIdentifier = [
+                {
+                  Name  = "Password"
+                  Regex = "(\"password\":\\s*\")([^\"]+)(\")"
+                },
+                {
+                  Name  = "SecretKey"
+                  Regex = "(SECRET_KEY=)([^\\s]+)"
+                }
+              ]
+            }
+            Statement = [
+              {
+                Sid = "audit-policy"
+                DataIdentifier = [
+                  "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
+                  "Password",
+                  "SecretKey"
+                ]
+                Operation = {
+                  Audit = {
+                    FindingsDestination = {}
+                  }
+                }
+              },
+              {
+                Sid = "redact-policy"
+                DataIdentifier = [
+                  "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
+                  "Password",
+                  "SecretKey"
+                ]
+                Operation = {
+                  Deidentify = {
+                    MaskConfig = {}
+                  }
+                }
+              }
+            ]
+          })
+        }
+      }
+    }
+  })
+}


### PR DESCRIPTION
This will prevent sensitive information, so far `password`s and `SECRET_KEY`s from leaking into logs. This is the initial implementation, however we anticipate that the list of `DataIdentifiers` to grow.

This has been tested in the `Dev` account, see screenshot attached below to see how masked values appear in the CloudWatch console.

![Screenshot 2024-07-03 at 09 49 19](https://github.com/uktrade/terraform-module-aws_account/assets/57071686/257814fb-d256-4eb8-8c2f-618afe3199fd)