### PR TITLE
Allow the CodeStar connection name to be overridden

### DIFF
--- a/org-common/codestar.tf
+++ b/org-common/codestar.tf
@@ -1,5 +1,5 @@
 resource "aws_codestarconnections_connection" "github" {
   provider      = aws.common
-  name          = "conn-github"
+  name          = var.codestar_connection_name
   provider_type = "GitHub"
 }

--- a/org-common/variables.tf
+++ b/org-common/variables.tf
@@ -1,42 +1,47 @@
+variable "codestar_connection_name" {
+  type    = string
+  default = "conn-github"
+}
+
 variable "org" {
   type = any
 }
 
 variable "password_policy_minimum_password_length" {
-    type = number
-    default = 8
+  type    = number
+  default = 8
 }
 
 variable "password_policy_require_lowercase_characters" {
-    type = bool
-    default = true
+  type    = bool
+  default = true
 }
 
 variable "password_policy_require_numbers" {
-    type = bool
-    default = true
+  type    = bool
+  default = true
 }
 
 variable "password_policy_require_uppercase_characters" {
-    type = bool
-    default = true
+  type    = bool
+  default = true
 }
 variable "password_policy_require_symbols" {
-    type = bool
-    default = true
+  type    = bool
+  default = true
 }
 
 variable "password_policy_allow_users_to_change_password" {
-    type = bool
-    default = true
+  type    = bool
+  default = true
 }
 
 variable "password_policy_password_reuse_prevention" {
-    type = number
-    default = 24
+  type    = number
+  default = 24
 }
 
 variable "password_policy_max_password_age" {
-    type = number
-    default = 0
+  type    = number
+  default = 0
 }


### PR DESCRIPTION
This will allow us to have CodeStar connections that match the name expected by copilot.