### PR TITLE
Add 'copilot-application' tag for CodeStar connection

### DIFF
--- a/org-common/codestar.tf
+++ b/org-common/codestar.tf
@@ -2,4 +2,7 @@ resource "aws_codestarconnections_connection" "github" {
   provider      = aws.common
   name          = var.codestar_connection_name
   provider_type = "GitHub"
+  tags          = {
+    copilot-application = var.codestar_connection_name
+  }
 }


### PR DESCRIPTION
This tag seems to be present for the CodeStar connections that I have been importing, let's add it into the Terraform so that the connections don't lose their tags.