### PR TITLE
Bring CodeStar connection tags in line with Platform Team convention

### DIFF
--- a/org-common/codestar.tf
+++ b/org-common/codestar.tf
@@ -3,6 +3,8 @@ resource "aws_codestarconnections_connection" "github" {
   name          = var.codestar_connection_name
   provider_type = "GitHub"
   tags          = {
+    application         = var.codestar_connection_name
     copilot-application = var.codestar_connection_name
+    managed-by          = "DBT SRE - Terraform"
   }
 }


### PR DESCRIPTION
This PR brings the CodeStar connection tags in line with the Platform Team convention as per this comment:
<https://github.com/uktrade/terraform-module-aws_account/pull/60/files#r1670088316>