### PR TITLE
Create Slack Notification only when required

### DIFF
--- a/org-member/backup.tf
+++ b/org-member/backup.tf
@@ -52,6 +52,7 @@ resource "aws_sns_topic_subscription" "org_backup_sns_to_lambda" {
 
 ## Lambda
 
+# Only create the lambda if the createslacklambda variable has been set to true
 resource "aws_lambda_permission" "aws_lambda_from_member_sns" {
   provider      = aws.master
   count         = try(var.member.createslacklambda == true ? 1 : 0, 0)

--- a/org-member/backup.tf
+++ b/org-member/backup.tf
@@ -54,6 +54,7 @@ resource "aws_sns_topic_subscription" "org_backup_sns_to_lambda" {
 
 resource "aws_lambda_permission" "aws_lambda_from_member_sns" {
   provider      = aws.master
+  count         = try(var.member.createslacklambda == true ? 1 : 0, 0)
   statement_id  = "AllowExecutionFromMember_${data.aws_caller_identity.member.account_id}"
   principal     = "sns.amazonaws.com"
   action        = "lambda:InvokeFunction"

--- a/org-member/vpc-flowlog.tf
+++ b/org-member/vpc-flowlog.tf
@@ -37,7 +37,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "vpc_log_lifecycle" {
       days = 90
     }
     abort_incomplete_multipart_upload {
-     days_after_initiation = 7
+      days_after_initiation = 7
     }
   }
 }
@@ -61,7 +61,7 @@ data "aws_iam_policy_document" "vpc_log" {
     effect  = "Deny"
     resources = [
       "${aws_s3_bucket.vpc_log.arn}",
-      "${aws_s3_bucket.vpc_log.arn}/*"     
+      "${aws_s3_bucket.vpc_log.arn}/*"
     ]
     condition {
       test     = "Bool"


### PR DESCRIPTION
# Description

AWS Backup Alerts to Slack were created in PR #11. These have been created for every member account in the organisation. This has now caused an issue where any further alerts cannot be created as the lambda policy has reached its limit.

<img width="1331" alt="image" src="https://github.com/uktrade/terraform-module-aws_account/assets/5746804/2421fb2a-a79e-4241-98b4-dca2512151ba">

To resolve this a variable `createslacklambda` has been created. If this is set to `true` then it will be created for a new account.

`createslacklambda=true`

For any account that this is not needed e.g. `Dev` setting this variable to `false` will destroy it as shown below

<img width="770" alt="image" src="https://github.com/uktrade/terraform-module-aws_account/assets/5746804/178da23a-19fc-4be0-a25d-8ca65a15c17c">

The variable can be thus used to manage lambda creation from AWS accounts.

## Contributors

@shehzadashiq 

## Type of change

- [ ] Refactoring (made code better without changing its behaviour)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

This has been tested with new accounts. It only creates the slack lambda if it has been enabled

<img width="695" alt="image" src="https://github.com/uktrade/terraform-module-aws_account/assets/5746804/491bb6b9-1509-43f0-a180-8cbfd056979e">

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings