### PR TITLE
Add SSM parameters with default config for the ADOT ECS sidecar image

### DIFF
--- a/org-member/adot-prometheus-config.yaml.tmpl
+++ b/org-member/adot-prometheus-config.yaml.tmpl
@@ -1,0 +1,112 @@
+receivers:
+  awsecscontainermetrics: # collect 52 metrics
+  # available metrics: https://aws-otel.github.io/docs/components/ecs-metrics-receiver#available-metrics
+
+extensions:
+  sigv4auth:
+    service: "aps"
+    region: "eu-west-2"
+    assume_role:
+      arn: "${assume_role}"
+      sts_region: "eu-west-2"
+
+processors:
+  filter: # filter metrics
+    metrics:
+      include:
+        match_type: strict
+        metric_names: # select only 8 task level metrics out of 52
+          # full list of metrics here: https://aws-otel.github.io/docs/components/ecs-metrics-receiver#available-metrics
+          # task level metrics
+          - ecs.task.memory.reserved
+          - ecs.task.memory.utilized
+          - ecs.task.cpu.reserved
+          - ecs.task.cpu.utilized
+          - ecs.task.network.rate.rx
+          - ecs.task.network.rate.tx
+          - ecs.task.storage.read_bytes
+          - ecs.task.storage.write_bytes
+          # Container level metrics
+          - container.memory.reserved
+          - container.memory.utilized
+          - container.cpu.reserved
+          - container.cpu.utilized
+          - container.network.rate.rx
+          - container.network.rate.tx
+          - container.storage.read_bytes
+          - container.storage.write_bytes
+
+  metricstransform: # update metric names
+  # docs: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/metricstransformprocessor/README.md
+    transforms:
+      # task metrics
+      - include: ecs.task.memory.reserved
+        action: update
+        new_name: TaskMemoryReserved
+      - include: ecs.task.memory.utilized
+        action: update
+        new_name: TaskMemoryUtilized
+      - include: ecs.task.cpu.reserved
+        action: update
+        new_name: TaskCpuReserved
+      - include: ecs.task.cpu.utilized
+        action: update
+        new_name: TaskCpuUtilised
+      - include: ecs.task.network.rate.rx
+        action: update
+        new_name: TaskNetworkRxBytes
+      - include: ecs.task.network.rate.tx
+        action: update
+        new_name: TaskNetworkTxBytes
+      - include: ecs.task.storage.read_bytes
+        action: update
+        new_name: TaskStorageReadBytes
+      - include: ecs.task.storage.write_bytes
+        action: update
+        new_name: TaskStorageWriteBytes
+      # container metrics
+      - include: container.memory.reserved
+        action: update
+        new_name: ContainerMemoryReserved
+      - include: container.memory.utilized
+        action: update
+        new_name: ContainerMemoryUtilized
+      - include: container.cpu.reserved
+        action: update
+        new_name: ContainerCpuReserved
+      - include: container.cpu.utilized
+        action: update
+        new_name: ContainerCpuUtilised
+      - include: container.network.rate.rx
+        action: update
+        new_name: ContainerNetworkRxBytes
+      - include: container.network.rate.tx
+        action: update
+        new_name: ContainerNetworkTxBytes
+      - include: container.storage.read_bytes
+        action: update
+        new_name: ContainerStorageReadBytes
+      - include: container.storage.write_bytes
+        action: update
+        new_name: ContainerStorageWriteBytes
+exporters:
+  logging:
+    verbosity: detailed
+  prometheusremotewrite:
+    endpoint: ${endpoint}
+    auth:
+      authenticator: sigv4auth
+    add_metric_suffixes: false
+    external_labels:
+      Application: $${env:COPILOT_APPLICATION_NAME}
+      Environment: $${env:COPILOT_ENVIRONMENT_NAME}
+      Service: $${env:COPILOT_SERVICE_NAME}
+    resource_to_telemetry_conversion:
+      enabled: true # Convert resource attributes to metric labels
+service:
+  pipelines:
+    metrics:
+      receivers: [awsecscontainermetrics ]
+      processors: [filter, metricstransform]
+      exporters: [ logging, prometheusremotewrite ]
+  extensions: [sigv4auth]

--- a/org-member/adot-prometheus-config.yaml.tmpl
+++ b/org-member/adot-prometheus-config.yaml.tmpl
@@ -108,5 +108,7 @@ service:
     metrics:
       receivers: [awsecscontainermetrics ]
       processors: [filter, metricstransform]
-      exporters: [ logging, prometheusremotewrite ]
+      # Add logging to the exporters list to get debug output
+      #exporters: [ logging, prometheusremotewrite ]
+      exporters: [ prometheusremotewrite ]
   extensions: [sigv4auth]

--- a/org-member/adot-prometheus-ssm.tf
+++ b/org-member/adot-prometheus-ssm.tf
@@ -1,0 +1,35 @@
+locals {
+  tags = {
+    managed-by = "DBT Platform - Terraform"
+  }
+
+  prod = {
+    assume_role = "arn:aws:iam::480224066791:role/amp-prometheus-role"
+    endpoint = "https://aps-workspaces.eu-west-2.amazonaws.com/workspaces/ws-7297af06-7c1a-4bfc-affd-4abe053797e16e/api/v1/remote_write"
+  }
+
+  dev = {
+    assume_role = "arn:aws:iam::480224066791:role/amp-prometheus-dev-role"
+    endpoint = "https://aps-workspaces.eu-west-2.amazonaws.com/workspaces/ws-d9fd4d97-49cc-4b89-9f4c-025e275704eec6/api/v1/remote_write"
+  }
+}
+
+resource "aws_ssm_parameter" "adot-prometheus-dev-config" {
+  name            = "/observability/prometheus-dev/adot_config"
+  description     = "Configuration to enable the ADOT sidecar image to ship an ECS service contaniers metrics into Prometheus."
+  type            = "String"
+  insecure_value  = templatefile("${path.module}/adot-prometheus-config.yaml.tmpl", local.dev)
+  tier            = "Intelligent-Tiering"
+
+  tags = local.tags
+}
+
+resource "aws_ssm_parameter" "adot-prometheus-config" {
+  name            = "/observability/prometheus/adot_config"
+  description     = "Configuration to enable the ADOT sidecar image to ship an ECS service contaniers metrics into Prometheus."
+  type            = "String"
+  insecure_value  = templatefile("${path.module}/adot-prometheus-config.yaml.tmpl", local.prod)
+  tier            = "Intelligent-Tiering"
+
+  tags = local.tags
+}

--- a/org-member/adot-prometheus-ssm.tf
+++ b/org-member/adot-prometheus-ssm.tf
@@ -16,7 +16,7 @@ locals {
 
 resource "aws_ssm_parameter" "adot-prometheus-dev-config" {
   name            = "/observability/prometheus-dev/adot_config"
-  description     = "Configuration to enable the ADOT sidecar image to ship an ECS service contaniers metrics into Prometheus."
+  description     = "Configuration to enable the ADOT sidecar image to ship ECS container metrics into Prometheus."
   type            = "String"
   insecure_value  = templatefile("${path.module}/adot-prometheus-config.yaml.tmpl", local.dev)
   tier            = "Intelligent-Tiering"
@@ -26,7 +26,7 @@ resource "aws_ssm_parameter" "adot-prometheus-dev-config" {
 
 resource "aws_ssm_parameter" "adot-prometheus-config" {
   name            = "/observability/prometheus/adot_config"
-  description     = "Configuration to enable the ADOT sidecar image to ship an ECS service contaniers metrics into Prometheus."
+  description     = "Configuration to enable the ADOT sidecar image to ship ECS container metrics into Prometheus."
   type            = "String"
   insecure_value  = templatefile("${path.module}/adot-prometheus-config.yaml.tmpl", local.prod)
   tier            = "Intelligent-Tiering"


### PR DESCRIPTION

# Description

This enables services running in ECS/DBT Platform to configure the ADOT (AWS Distro for Open Telemetry) sidecar image to ship local container metrics into the dev and prod promeheus workspaces in the `sre-tools` AWS account.

Example usage from a copilot service manifest.yml:

```
sidecars:
  otel_sidecar:
    image: 'public.ecr.aws/aws-observability/aws-otel-collector:latest'
    secrets:
      AOT_CONFIG_CONTENT: /observability/prometheus/adot_config
```

## Contributors

Let's acknowledge the people who contributed to the work.

## Type of change

- [ ] Refactoring (made code better without changing its behaviour)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

I tested the terraform config in a separate stack.  I haven't attempted to run the terraform aws account stack, yet.

If they are not automated tests please explain why and provide screenshots and/or instructions so they can reproduced.

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
