### PR TITLE
Enable Cost And Compute Optimisation At Organisation Level

### DIFF
--- a/org-master/cost.tf
+++ b/org-master/cost.tf
@@ -1,0 +1,5 @@
+resource "aws_organizations_policy" "org_cost_policy" {
+  provider = aws.master
+  name     = "cost-optimisation-policy"
+  content  = file("${path.module}/policies/org-policy-cost-optimisation.json")
+}

--- a/org-master/org.tf
+++ b/org-master/org.tf
@@ -16,7 +16,9 @@ resource "aws_organizations_organization" "org" {
     "controltower.amazonaws.com",
     "inspector2.amazonaws.com",
     "member.org.stacksets.cloudformation.amazonaws.com",
-    "health.amazonaws.com"
+    "health.amazonaws.com",
+    "cost-optimization-hub.bcm.amazonaws.com",
+    "compute-optimizer.amazonaws.com"
   ]
   enabled_policy_types = [
     "BACKUP_POLICY",

--- a/org-master/policies/org-policy-cost-optimisation.json
+++ b/org-master/policies/org-policy-cost-optimisation.json
@@ -1,0 +1,50 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "CostOptimizationHubAdminAccess",
+            "Effect": "Allow",
+            "Action": [
+                "cost-optimization-hub:ListEnrollmentStatuses",
+                "cost-optimization-hub:UpdateEnrollmentStatus",
+                "cost-optimization-hub:GetPreferences",
+                "cost-optimization-hub:UpdatePreferences",
+                "cost-optimization-hub:GetRecommendation",
+                "cost-optimization-hub:ListRecommendations",
+                "cost-optimization-hub:ListRecommendationSummaries",
+                "organizations:EnableAWSServiceAccess"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "AllowCreationOfServiceLinkedRoleForCostOptimizationHub",
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateServiceLinkedRole"
+            ],
+            "Resource": [
+                "arn:aws:iam::*:role/aws-service-role/cost-optimization-hub.bcm.amazonaws.com/AWSServiceRoleForCostOptimizationHub"
+            ],
+            "Condition": {
+                "StringLike": {
+                    "iam:AWSServiceName": "cost-optimization-hub.bcm.amazonaws.com"
+                }
+            }
+        },
+        {
+            "Sid": "AllowAWSServiceAccessForCostOptimizationHub",
+            "Effect": "Allow",
+            "Action": [
+                "organizations:EnableAWSServiceAccess"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringLike": {
+                    "organizations:ServicePrincipal": [
+                        "cost-optimization-hub.bcm.amazonaws.com"
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/org-member/cost.tf
+++ b/org-member/cost.tf
@@ -1,0 +1,6 @@
+resource "aws_iam_role" "cost_optimisation" {
+  provider           = aws.member
+  name               = "dit-cost-optimisation"
+  description        = "Role used by AWS provides the permissions necessary for a member account to have full access to Cost Optimization Hub."
+  assume_role_policy = file("${path.module}/policies/org-policy-cost-member.json")
+}

--- a/org-member/policies/org-policy-cost-member.json
+++ b/org-member/policies/org-policy-cost-member.json
@@ -1,0 +1,19 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "CostOptimizationHubAdminAccess",
+            "Effect": "Allow",
+            "Action": [
+                "cost-optimization-hub:ListEnrollmentStatuses",
+                "cost-optimization-hub:UpdateEnrollmentStatus",
+                "cost-optimization-hub:GetPreferences",
+                "cost-optimization-hub:UpdatePreferences",
+                "cost-optimization-hub:GetRecommendation",
+                "cost-optimization-hub:ListRecommendations",
+                "cost-optimization-hub:ListRecommendationSummaries"
+            ],
+            "Resource": "*"
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Cost and Compute Optimisation have been enabled in the organisation. However Terraform does not account for this. This PR will enable this at the organisation level as outlined here.

[Roll out Cost Optimisation Hub using Terraform](https://uktrade.atlassian.net/browse/SR-2681)

Compute Optimisation has also been enabled as a service control policy.

[Controlling access with AWS Identity and Access Management](https://docs.aws.amazon.com/compute-optimizer/latest/ug/security-iam.html#organization-account-access)

## Contributors

@shehzadashiq 

## Type of change

- [ ] Refactoring (made code better without changing its behaviour)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

A branch was created with the applied changes with the following output when `terraform plan` is applied.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
