### PR TITLE
Add tags to SSM parameters to allow Copilot services to read them

### DIFF
--- a/org-member/adot-prometheus-config.yaml.tmpl
+++ b/org-member/adot-prometheus-config.yaml.tmpl
@@ -189,7 +189,7 @@ service:
   pipelines:
     metrics:
       receivers: [awsecscontainermetrics ]
-      processors: [filter, metricstransform]
+      processors: [metricstransform]
       # Add logging to the exporters list to get debug output, e.g:
       #exporters: [ logging, prometheusremotewrite ]
       exporters: [ prometheusremotewrite ]

--- a/org-member/adot-prometheus-config.yaml.tmpl
+++ b/org-member/adot-prometheus-config.yaml.tmpl
@@ -1,6 +1,6 @@
+# docs: https://aws-otel.github.io/docs/components/ecs-metrics-receiver
 receivers:
   awsecscontainermetrics: # collect 52 metrics
-  # available metrics: https://aws-otel.github.io/docs/components/ecs-metrics-receiver#available-metrics
 
 extensions:
   sigv4auth:
@@ -11,82 +11,164 @@ extensions:
       sts_region: "eu-west-2"
 
 processors:
-  filter: # filter metrics
-    metrics:
-      include:
-        match_type: strict
-        metric_names: # select only 8 task level metrics out of 52
-          # full list of metrics here: https://aws-otel.github.io/docs/components/ecs-metrics-receiver#available-metrics
-          # task level metrics
-          - ecs.task.memory.reserved
-          - ecs.task.memory.utilized
-          - ecs.task.cpu.reserved
-          - ecs.task.cpu.utilized
-          - ecs.task.network.rate.rx
-          - ecs.task.network.rate.tx
-          - ecs.task.storage.read_bytes
-          - ecs.task.storage.write_bytes
-          # Container level metrics
-          - container.memory.reserved
-          - container.memory.utilized
-          - container.cpu.reserved
-          - container.cpu.utilized
-          - container.network.rate.rx
-          - container.network.rate.tx
-          - container.storage.read_bytes
-          - container.storage.write_bytes
-
   metricstransform: # update metric names
-  # docs: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/metricstransformprocessor/README.md
     transforms:
-      # task metrics
-      - include: ecs.task.memory.reserved
+      ### task metrics
+      - include: ecs.task.memory.usage  # type: Bytes
+        action: update
+        new_name: TaskMemoryUsage
+      - include: ecs.task.memory.usage.max  # type: Bytes
+        action: update
+        new_name: TaskMemoryUsageMax
+      - include: ecs.task.memory.usage.limit  # type: Bytes
+        action: update
+        new_name: TaskMemoryUsageLimit
+      - include: ecs.task.memory.reserved  # type: Megabytes
         action: update
         new_name: TaskMemoryReserved
-      - include: ecs.task.memory.utilized
+      - include: ecs.task.memory.utilized  # type: Megabytes
         action: update
         new_name: TaskMemoryUtilized
-      - include: ecs.task.cpu.reserved
+      - include: ecs.task.cpu.usage.total  # type: Nanoseconds
+        action: update
+        new_name: TaskCpuUsageTotal
+      - include: ecs.task.cpu.usage.kernelmode  # type: Nanoseconds
+        action: update
+        new_name: TaskCpuUsageKernelmode
+      - include: ecs.task.cpu.usage.usermode  # type: Nanoseconds
+        action: update
+        new_name: TaskCpuUsageUsermode
+      - include: ecs.task.cpu.usage.system  # type: Nanoseconds
+        action: update
+        new_name: TaskCpuUsageSystem
+      - include: ecs.task.cpu.usage.vcpu  # type: vCPU
+        action: update
+        new_name: TaskCpuUsageVcpu
+      - include: ecs.task.cpu.cores  # type: Count
+        action: update
+        new_name: TaskCpuCores
+      - include: ecs.task.cpu.onlines  # type: Count
+        action: update
+        new_name: TaskCpuOnlines
+      - include: ecs.task.cpu.reserved  # type: vCPU
         action: update
         new_name: TaskCpuReserved
-      - include: ecs.task.cpu.utilized
+      - include: ecs.task.cpu.utilized  # type: Percent
         action: update
-        new_name: TaskCpuUtilised
-      - include: ecs.task.network.rate.rx
+        new_name: TaskCpuUtilized
+      - include: ecs.task.network.rate.rx  # type: Bytes/Second
         action: update
-        new_name: TaskNetworkRxBytes
-      - include: ecs.task.network.rate.tx
+        new_name: TaskNetworkRateRx
+      - include: ecs.task.network.rate.tx  # type: Bytes/Second
         action: update
-        new_name: TaskNetworkTxBytes
-      - include: ecs.task.storage.read_bytes
+        new_name: TaskNetworkRateTx
+      - include: ecs.task.network.io.usage.rx_bytes  # type: Bytes
+        action: update
+        new_name: TaskNetworkIoUsageRxBytes
+      - include: ecs.task.network.io.usage.rx_packets  # type: Count
+        action: update
+        new_name: TaskNetworkIoUsageRxPackets
+      - include: ecs.task.network.io.usage.rx_errors  # type: Count
+        action: update
+        new_name: TaskNetworkIoUsageRxErrors
+      - include: ecs.task.network.io.usage.rx_dropped  # type: Count
+        action: update
+        new_name: TaskNetworkIoUsageRxDropped
+      - include: ecs.task.network.io.usage.tx_bytes  # type: Bytes
+        action: update
+        new_name: TaskNetworkIoUsageTxBytes
+      - include: ecs.task.network.io.usage.tx_packets  # type: Count
+        action: update
+        new_name: TaskNetworkIoUsageTxPackets
+      - include: ecs.task.network.io.usage.tx_errors  # type: Count
+        action: update
+        new_name: TaskNetworkIoUsageTxErrors
+      - include: ecs.task.network.io.usage.tx_dropped  # type: Count
+        action: update
+        new_name: TaskNetworkIoUsageTxDropped
+      - include: ecs.task.storage.read_bytes  # type: Bytes
         action: update
         new_name: TaskStorageReadBytes
-      - include: ecs.task.storage.write_bytes
+      - include: ecs.task.storage.write_bytes  # type: Bytes
         action: update
         new_name: TaskStorageWriteBytes
-      # container metrics
-      - include: container.memory.reserved
+      ### container metrics
+      - include: container.memory.usage  # type: Bytes
+        action: update
+        new_name: ContainerMemoryUsage
+      - include: container.memory.usage.max  # type: Bytes
+        action: update
+        new_name: ContainerMemoryUsageMax
+      - include: container.memory.usage.limit  # type: Bytes
+        action: update
+        new_name: ContainerMemoryUsageLimit
+      - include: container.memory.reserved  # type: Megabytes
         action: update
         new_name: ContainerMemoryReserved
-      - include: container.memory.utilized
+      - include: container.memory.utilized  # type: Megabytes
         action: update
         new_name: ContainerMemoryUtilized
-      - include: container.cpu.reserved
+      - include: container.cpu.usage.total  # type: Nanoseconds
+        action: update
+        new_name: ContainerCpuUsageTotal
+      - include: container.cpu.usage.kernelmode  # type: Nanoseconds
+        action: update
+        new_name: ContainerCpuUsageKernelmode
+      - include: container.cpu.usage.usermode  # type: Nanoseconds
+        action: update
+        new_name: ContainerCpuUsageUsermode
+      - include: container.cpu.usage.system  # type: Nanoseconds
+        action: update
+        new_name: ContainerCpuUsageSystem
+      - include: container.cpu.usage.vcpu  # type: vCPU
+        action: update
+        new_name: ContainerCpuUsageVcpu
+      - include: container.cpu.cores  # type: Count
+        action: update
+        new_name: ContainerCpuCores
+      - include: container.cpu.onlines  # type: Count
+        action: update
+        new_name: ContainerCpuOnlines
+      - include: container.cpu.reserved  # type: vCPU
         action: update
         new_name: ContainerCpuReserved
-      - include: container.cpu.utilized
+      - include: container.cpu.utilized  # type: Percent
         action: update
-        new_name: ContainerCpuUtilised
-      - include: container.network.rate.rx
+        new_name: ContainerCpuUtilized
+      - include: container.network.rate.rx  # type: Bytes/Second
         action: update
-        new_name: ContainerNetworkRxBytes
-      - include: container.network.rate.tx
+        new_name: ContainerNetworkRateRx
+      - include: container.network.rate.tx  # type: Bytes/Second
         action: update
-        new_name: ContainerNetworkTxBytes
-      - include: container.storage.read_bytes
+        new_name: ContainerNetworkRateTx
+      - include: container.network.io.usage.rx_bytes  # type: Bytes
+        action: update
+        new_name: ContainerNetworkIoUsageRxBytes
+      - include: container.network.io.usage.rx_packets  # type: Count
+        action: update
+        new_name: ContainerNetworkIoUsageRxPackets
+      - include: container.network.io.usage.rx_errors  # type: Count
+        action: update
+        new_name: ContainerNetworkIoUsageRxErrors
+      - include: container.network.io.usage.rx_dropped  # type: Count
+        action: update
+        new_name: ContainerNetworkIoUsageRxDropped
+      - include: container.network.io.usage.tx_bytes  # type: Bytes
+        action: update
+        new_name: ContainerNetworkIoUsageTxBytes
+      - include: container.network.io.usage.tx_packets  # type: Count
+        action: update
+        new_name: ContainerNetworkIoUsageTxPackets
+      - include: container.network.io.usage.tx_errors  # type: Count
+        action: update
+        new_name: ContainerNetworkIoUsageTxErrors
+      - include: container.network.io.usage.tx_dropped  # type: Count
+        action: update
+        new_name: ContainerNetworkIoUsageTxDropped
+      - include: container.storage.read_bytes  # type: Bytes
         action: update
         new_name: ContainerStorageReadBytes
-      - include: container.storage.write_bytes
+      - include: container.storage.write_bytes  # type: Bytes
         action: update
         new_name: ContainerStorageWriteBytes
 exporters:
@@ -108,7 +190,7 @@ service:
     metrics:
       receivers: [awsecscontainermetrics ]
       processors: [filter, metricstransform]
-      # Add logging to the exporters list to get debug output
+      # Add logging to the exporters list to get debug output, e.g:
       #exporters: [ logging, prometheusremotewrite ]
       exporters: [ prometheusremotewrite ]
   extensions: [sigv4auth]

--- a/org-member/adot-prometheus-ssm.tf
+++ b/org-member/adot-prometheus-ssm.tf
@@ -1,8 +1,4 @@
 locals {
-  tags = {
-    managed-by = "DBT Platform - Terraform"
-  }
-
   prod = {
     assume_role = "arn:aws:iam::480224066791:role/amp-prometheus-role"
     endpoint    = "https://aps-workspaces.eu-west-2.amazonaws.com/workspaces/ws-7297af06-7c1a-4bfc-affd-4abe053797e16e/api/v1/remote_write"
@@ -23,7 +19,7 @@ resource "aws_ssm_parameter" "adot-prometheus-dev-config" {
   insecure_value = templatefile("${path.module}/adot-prometheus-config.yaml.tmpl", local.dev)
   tier           = "Intelligent-Tiering"
 
-  tags = local.tags
+  tags = local.ssm_tags
 }
 
 resource "aws_ssm_parameter" "adot-prometheus-config" {
@@ -35,5 +31,5 @@ resource "aws_ssm_parameter" "adot-prometheus-config" {
   insecure_value = templatefile("${path.module}/adot-prometheus-config.yaml.tmpl", local.prod)
   tier           = "Intelligent-Tiering"
 
-  tags = local.tags
+  tags = local.ssm_tags
 }

--- a/org-member/local.tf
+++ b/org-member/local.tf
@@ -4,4 +4,10 @@ locals {
   sentinel_common_resource_tag_value = "Microsoft_Sentinel_Automation_Script"
   sentinel_common_resource_tag       = { "${local.sentinel_common_resource_tag_name}" = "${local.sentinel_common_resource_tag_value}" }
   aws_organization_id                = element(split("/", var.org["organization_arn"]), 1)
+
+  # Tags for SSM paremeters defined in loggroups.tf and adot-prometheus-ssm.tf.
+  ssm_tags = {
+    managed-by = "DBT Platform - Terraform"
+    copilot-application = "__all__"
+  }
 }

--- a/org-member/loggroups.tf
+++ b/org-member/loggroups.tf
@@ -1,7 +1,7 @@
 # Create log groups for accounts.
 # At time of writing (29th Feb 2024) I wasn't sure if we wanted to roll this out to all accounts.
-# So I've added in a 'count' to act as an if statement. 
-# e.g. if var.member.createloggroups == true, set count to 1 and create the resource. 
+# So I've added in a 'count' to act as an if statement.
+# e.g. if var.member.createloggroups == true, set count to 1 and create the resource.
 
 resource "aws_iam_role" "CWLtoSubscriptionFilterRole" {
   provider = aws.member
@@ -54,4 +54,6 @@ resource "aws_ssm_parameter" "central_log_groups" {
     "prod" : "arn:aws:logs:eu-west-2:${data.aws_caller_identity.logarchive.account_id}:destination:cwl_log_destination",
     "dev" : "arn:aws:logs:eu-west-2:${data.aws_caller_identity.logarchive.account_id}:destination:cwl_log_destination"
   })
+
+  tags = local.ssm_tags
 }


### PR DESCRIPTION


# Description

By default Copilot service can only read SSM paramters that are tagged wtih their name and environment.  We however have a need for global account wide SSM parameters that are consumable by any Copilot service in that account.  We already have a set of global SSM paramters but overlooked that an explicit policy was required for the service to be able to access the paramter.

This PR fixes this issue by adding a `Copilot-application: __all__` tag for these account wide SSM parameters. There's an associated PR in the platform-tools account that adds the policy to the Copilot/ECS task role.

https://uktrade.atlassian.net/browse/DBTP-1154

## Contributors

Let's acknowledge the people who contributed to the work.

## Type of change

- [ ] Refactoring (made code better without changing its behaviour)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

It has been manually tested with the Demodjango service.  

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
