### PR TITLE
Created cross-account CloudWatch observability config for accounts

### DIFF
--- a/org-member/main.tf
+++ b/org-member/main.tf
@@ -22,3 +22,6 @@ data "aws_caller_identity" "logarchive" {
   provider = aws.logarchive
 }
 
+data "aws_organizations_organization" "org" {
+  provider = aws.master
+}

--- a/org-member/oam.tf
+++ b/org-member/oam.tf
@@ -4,23 +4,23 @@
 
 # Create a 'sink' in the account you wish to monitor from
 resource "aws_oam_sink" "sink" {
-  provider      = aws.member
-  count = try(var.member.cw_monitoring_account, false) == true ? 1 : 0
-  name = "org-sink"
+  provider = aws.member
+  count    = try(var.member.cw_monitoring_account, false) == true ? 1 : 0
+  name     = "org-sink"
 }
 
 # Apply a policy to allow any account within our AWS Orgaization to access it.
 resource "aws_oam_sink_policy" "sink-policy" {
-  provider      = aws.member
-  count = try(var.member.cw_monitoring_account, false) == true ? 1 : 0
+  provider        = aws.member
+  count           = try(var.member.cw_monitoring_account, false) == true ? 1 : 0
   sink_identifier = aws_oam_sink.sink[0].id
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {
-        Action   = ["oam:CreateLink", "oam:UpdateLink"]
-        Effect   = "Allow"
-        Resource = "*"
+        Action    = ["oam:CreateLink", "oam:UpdateLink"]
+        Effect    = "Allow"
+        Resource  = "*"
         Principal = "*"
         Condition = {
           "StringEquals" = {
@@ -33,27 +33,27 @@ resource "aws_oam_sink_policy" "sink-policy" {
 }
 
 resource "aws_ssm_parameter" "oam-sink-id" {
-  provider = aws.ci
-  count = try(var.member.cw_monitoring_account, false) == true ? 1 : 0
-  name = "/observability/sink/id"
+  provider    = aws.ci
+  count       = try(var.member.cw_monitoring_account, false) == true ? 1 : 0
+  name        = "/observability/sink/id"
   description = "Sink ID from monitoring account"
-  type = "SecureString"
-  value = aws_oam_sink.sink[0].id
-  key_id = "alias/trade-terraform-parameter-store-key"
+  type        = "SecureString"
+  value       = aws_oam_sink.sink[0].id
+  key_id      = "alias/trade-terraform-parameter-store-key"
 }
 
 # The above ssm parameter resource won't exist for non-monitoring accounts,
 # So lets pull it down when we're dealing with a non-monitoring account.
 data "aws_ssm_parameter" "oam-sink-id" {
   provider = aws.ci
-  count = try(var.member.cw_monitoring_account, false) == false ? 1 : 0
-  name = "/observability/sink/id"
+  count    = try(var.member.cw_monitoring_account, false) == false ? 1 : 0
+  name     = "/observability/sink/id"
 }
 
 # Create a link to the sink created above from all other accounts:
 resource "aws_oam_link" "link" {
-  provider = aws.member
-  count = try(var.member.cw_monitoring_account, false) == false ? 1 : 0
+  provider        = aws.member
+  count           = try(var.member.cw_monitoring_account, false) == false ? 1 : 0
   label_template  = "$AccountName"
   resource_types  = ["AWS::CloudWatch::Metric", "AWS::Logs::LogGroup"]
   sink_identifier = data.aws_ssm_parameter.oam-sink-id[0].value

--- a/org-member/oam.tf
+++ b/org-member/oam.tf
@@ -1,0 +1,60 @@
+#Observability Access Manager
+# To enable Cross-account CloudWatch visibility. 
+# This allows us to monitor all CloudWatch stats from a single account rather than switching between multiple ones.
+
+# Create a 'sink' in the account you wish to monitor from
+resource "aws_oam_sink" "sink" {
+  provider      = aws.member
+  count = try(var.member.cw_monitoring_account, false) == true ? 1 : 0
+  name = "org-sink"
+}
+
+# Apply a policy to allow any account within our AWS Orgaization to access it.
+resource "aws_oam_sink_policy" "sink-policy" {
+  provider      = aws.member
+  count = try(var.member.cw_monitoring_account, false) == true ? 1 : 0
+  sink_identifier = aws_oam_sink.sink[0].id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action   = ["oam:CreateLink", "oam:UpdateLink"]
+        Effect   = "Allow"
+        Resource = "*"
+        Principal = "*"
+        Condition = {
+          "StringEquals" = {
+            "aws:PrincipalOrgID" = [data.aws_organizations_organization.org.id]
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_ssm_parameter" "oam-sink-id" {
+  provider = aws.ci
+  count = try(var.member.cw_monitoring_account, false) == true ? 1 : 0
+  name = "/observability/sink/id"
+  description = "Sink ID from monitoring account"
+  type = "SecureString"
+  value = aws_oam_sink.sink[0].id
+  key_id = "alias/trade-terraform-parameter-store-key"
+}
+
+# The above ssm parameter resource won't exist for non-monitoring accounts,
+# So lets pull it down when we're dealing with a non-monitoring account.
+data "aws_ssm_parameter" "oam-sink-id" {
+  provider = aws.ci
+  count = try(var.member.cw_monitoring_account, false) == false ? 1 : 0
+  name = "/observability/sink/id"
+}
+
+# Create a link to the sink created above from all other accounts:
+resource "aws_oam_link" "link" {
+  provider = aws.member
+  count = try(var.member.cw_monitoring_account, false) == false ? 1 : 0
+  label_template  = "$AccountName"
+  resource_types  = ["AWS::CloudWatch::Metric", "AWS::Logs::LogGroup"]
+  sink_identifier = data.aws_ssm_parameter.oam-sink-id[0].value
+}

--- a/org-member/versions.tf
+++ b/org-member/versions.tf
@@ -4,7 +4,7 @@ terraform {
     aws = {
       source                = "hashicorp/aws"
       version               = ">= 4.55"
-      configuration_aliases = [aws.master, aws.member, aws.logarchive]
+      configuration_aliases = [aws.master, aws.member, aws.logarchive, aws.ci]
     }
   }
 }


### PR DESCRIPTION
# Description

A request from Platforms for a centralised place to obtain CloudWatch metrics had come in. This PR adds in the functionality within the module to allow this to happen. It does the following:
- Based on a new field in `var.member` called `cw_monitoring_account` being true or false:
    - If true:
      This account is designated as a monitoring account, so it creates a `sink` in CloudWatch, attaches a `sink policy` that allows any account within our AWS organization to send data to it, and uploads the sink arn to parameter store in the `ci` account.
    - If false:
      This is a 'source account', that'll send its data over to the monitoring account, create a link resource using the arn stored in Parameter store and configure the types of CloudWatch resources to send over. Currently this is only set to send over Metrics and Log Groups data.

## Contributors

@gareth-e 

## Type of change

- [ ] Refactoring (made code better without changing its behaviour)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

This only added new functionality and was confirmed to be connecting source accounts to the monitoring account in CloudWatch settings.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
