### PR TITLE
Add application insights to dit-default-dev

### DIFF
--- a/org-member/iam.tf
+++ b/org-member/iam.tf
@@ -23,6 +23,7 @@ data "aws_iam_policy_document" "default_dev" {
     #checkov:skip=CKV_AWS_356:Ensure no IAM policies documents allow "*" as a statement's resource for restrictable actions
     actions = [
       "acm:*",
+      "applicationinsights:*",
       "athena:*",
       "cloudfront:*",
       "cloudtrail:*",


### PR DESCRIPTION
# Description

As part of [sre-request](https://ditdigitalteam.slack.com/archives/C1Q2EKZK3/p1726491893447829) adding the applicationinsights action to the dit-default-dev policy.

## Contributors

@jamesm-dbt 🙌 

## Type of change

- [ ] Refactoring (made code better without changing its behaviour)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

Tested in sandbox account:
<img width="1134" alt="Screenshot 2024-09-16 at 14 28 22" src="https://github.com/user-attachments/assets/f21b8850-ee2f-4362-99b6-a72a95aa6358">


## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
