### PR TITLE
Add a cross account Cloudwatch monitoring role

### DIFF
--- a/org-member/observability.tf
+++ b/org-member/observability.tf
@@ -1,0 +1,50 @@
+# A cross account monitoring role
+
+data "aws_iam_policy_document" "cloudwatch-monitoring-assume-role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::480224066791:role/cloudwatch-exporter-prod-exporter-TaskRole"]
+    }
+  }
+}
+
+resource "aws_iam_role" "cloudwatch-monitoring-role" {
+  name               = "cloudwatch-monitoring-role"
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
+}
+
+resource "aws_iam_role_policy" "cloudwatch-monitoring-policy" {
+  name = "test_policy"
+  role = aws_iam_role.cloudwatch-monitoring-role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+            "tag:GetResources",
+            "cloudwatch:GetMetricData",
+            "cloudwatch:GetMetricStatistics",
+            "cloudwatch:ListMetrics",
+            "apigateway:GET",
+            "aps:ListWorkspaces",
+            "autoscaling:DescribeAutoScalingGroups",
+            "dms:DescribeReplicationInstances",
+            "dms:DescribeReplicationTasks",
+            "ec2:DescribeTransitGatewayAttachments",
+            "ec2:DescribeSpotFleetRequests",
+            "shield:ListProtections",
+            "storagegateway:ListGateways",
+            "storagegateway:ListTagsForResource",
+            "iam:ListAccountAliases",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+}


### PR DESCRIPTION
The YACE (yet another cloudwatch exporter) image can't retrieve cross account metrics from the main monitoring account (sre-tools).  It can however assume roles in accounts and pull metrics directly.

This PR adds a cross account role that can be assume cross account by the YACE image to pull metrics.

# Description

Please include a summary of the changes and the related issue including relevant motivation and context. Please also include a link to the corresponding JIRA ticket this merge request addresses.

## Contributors

Let's acknowledge the people who contributed to the work.

## Type of change

- [ ] Refactoring (made code better without changing its behaviour)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

Please describe the tests that you ran to verify your changes.

If they are not automated tests please explain why and provide screenshots and/or instructions so they can reproduced.

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
