### PR TITLE
Add Resource Control Policies to Org

### DIFF
--- a/org-master/org-policy-attachment.tf
+++ b/org-master/org-policy-attachment.tf
@@ -1,0 +1,10 @@
+# Organisation Policy attachments 
+
+## Restrict SSE-C Uploads to S3. 
+### At time of writing (26th Feb 2025), we only wanted to enable this on non prod OUs
+### Once people are happy, we want to enable this on the root OU instead
+resource "aws_organizations_policy_attachment" "restrictSSECUploads" {
+  for_each = toset(var.rcp_accounts)
+  policy_id = aws_organizations_policy.restrictSSECUploads.id
+  target_id = aws_organizations_organizational_unit.org_ou_structure[each.key].id
+}

--- a/org-master/org-rcp.tf
+++ b/org-master/org-rcp.tf
@@ -1,0 +1,27 @@
+# Resource Control Policies
+
+## Restrict SSE-C Uploads
+data "aws_iam_policy_document" "restrictSSECUploads" {
+  statement {
+    sid = "RestrictSSECUploads"
+    effect    = "Deny"
+    actions   = ["s3:PutObject"]
+    resources = ["*"]
+    principals {
+      type = "*"
+      identifiers = [ "*" ]
+    }
+    condition {
+      test = "Null"
+      variable = "s3:x-amz-server-side-encryption-customer-algorithm"
+      values = ["false"]
+    }
+  }
+}
+
+resource "aws_organizations_policy" "restrictSSECUploads" {
+  name    = "RestrictSSECUploads"
+  content = data.aws_iam_policy_document.restrictSSECUploads.json
+  type = "RESOURCE_CONTROL_POLICY"
+}
+

--- a/org-master/org.tf
+++ b/org-master/org.tf
@@ -23,7 +23,8 @@ resource "aws_organizations_organization" "org" {
   ]
   enabled_policy_types = [
     "BACKUP_POLICY",
-    "SERVICE_CONTROL_POLICY"
+    "SERVICE_CONTROL_POLICY",
+    "RESOURCE_CONTROL_POLICY"
   ]
 }
 

--- a/org-master/variables.tf
+++ b/org-master/variables.tf
@@ -44,3 +44,8 @@ variable "org_ou_structure" {
 variable "deployment_environment" {
   type = string
 }
+
+variable "rcp_accounts" {
+  type = list(string)
+  default = []
+}

--- a/org-master/versions.tf
+++ b/org-master/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">= 4.55"
+      version               = ">= 5.77"
       configuration_aliases = [aws.master, aws.elk]
     }
   }


### PR DESCRIPTION
# Description

Added the ability to add Resource Control Policies to an AWS Organization.

## Contributors


## Type of change

- [ ] Refactoring (made code better without changing its behaviour)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

Terraform Plan does not output any unexpected changes related to this work.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
