### PR TITLE
Add api keys module that creates placeholder datadog api and app keys

### DIFF
--- a/datadog-api-keys/aws.tf
+++ b/datadog-api-keys/aws.tf
@@ -1,0 +1,35 @@
+data "aws_caller_identity" "current" {
+  provider = aws.member
+}
+
+locals {
+  tags = {
+    managed-by          = "DBT Platform - Terraform"
+  }
+
+  alias = var.account_alias
+}
+
+// Create some dummy/placeholder keys
+
+resource "aws_ssm_parameter" "datadog_api_key_placeholder" {
+  provider = aws.member
+
+  name        = "DATADOG_API_KEY"
+  description = "An API key for sending data to datadog for the ${local.alias} account only."
+  type        = "SecureString"
+  value       = "placeholder"
+
+  tags = local.tags
+}
+
+resource "aws_ssm_parameter" "datadog_app_key" {
+  provider = aws.member
+
+  name        = "DATADOG_APP_KEY"
+  description = "An APP key for sending data to datadog for the ${local.alias} account only."
+  type        = "SecureString"
+  value       = "placeholder"
+
+  tags = local.tags
+}

--- a/datadog-api-keys/variables.tf
+++ b/datadog-api-keys/variables.tf
@@ -1,0 +1,3 @@
+variable "account_alias" {
+  type = string
+}

--- a/datadog-api-keys/versions.tf
+++ b/datadog-api-keys/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.2.6"
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = ">= 4.55"
+      configuration_aliases = [aws.member]
+    }
+    datadog = {
+      source = "DataDog/datadog"
+    }
+  }
+}


### PR DESCRIPTION
# Description

Parts of DBT platform require DATADOG_API_KEY and DATADOG_APP_KEYS to exist and break loudly if they aren't found.  As temporary measure we're creating placeholder keys in each account.  

## Contributors

Let's acknowledge the people who contributed to the work.

## Type of change

- [ ] Refactoring (made code better without changing its behaviour)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

Please describe the tests that you ran to verify your changes.

If they are not automated tests please explain why and provide screenshots and/or instructions so they can reproduced.

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
