### PR TITLE
Add cross account billing policy for datadog

### DIFF
--- a/datadog/aws.tf
+++ b/datadog/aws.tf
@@ -299,7 +299,7 @@ resource "aws_iam_policy" "datadog_billing_policy" {
   policy = data.aws_iam_policy_document.dd_cloud_cost[0].json
 }
 
-resource "aws_iam_role_policy_attachment" "datadog_aws_integration" {
+resource "aws_iam_role_policy_attachment" "datadog_aws_billing_policy" {
   count = var.is_master ? 1 : 0
 
   provider = aws.member

--- a/datadog/aws.tf
+++ b/datadog/aws.tf
@@ -295,7 +295,7 @@ resource "aws_iam_policy" "datadog_billing_policy" {
 
   provider = aws.member
 
-  name   = "DatadogAWSIntegrationPolicy"
+  name   = "DatadogAWSBillingPolicy"
   policy = data.aws_iam_policy_document.dd_cloud_cost[0].json
 }
 

--- a/datadog/aws.tf
+++ b/datadog/aws.tf
@@ -236,7 +236,7 @@ resource "aws_iam_role_policy_attachment" "datadog_aws_integration_security_audi
   policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
 }
 
-# Additional policies so that the master account can retreive cross account billing information
+# Additional policies so that datadog can retrieve centralised billing information from the master account
 
 data "aws_iam_policy_document" "dd_cloud_cost" {
   count = var.is_master ? 1 : 0

--- a/datadog/variables.tf
+++ b/datadog/variables.tf
@@ -6,3 +6,8 @@ variable "connect_aws_account" {
   type = bool
   default = true
 }
+
+variable "is_master" {
+  type = bool
+  default = false
+}


### PR DESCRIPTION
# Description

This PR adds an `is_master` option for the datadog module, which defaults to false.  If `is_master=true` then additional policies are added which allows datadog to access centralised billing information. This is needed so that we can get billing information into datadog from the billing aws account.

## Contributors

Let's acknowledge the people who contributed to the work.

## Type of change

- [ ] Refactoring (made code better without changing its behaviour)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

Please describe the tests that you ran to verify your changes.

If they are not automated tests please explain why and provide screenshots and/or instructions so they can reproduced.

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
