### PR TITLE
fix: add tags to SSM params

### DIFF
--- a/datadog/keys.tf
+++ b/datadog/keys.tf
@@ -14,7 +14,9 @@ resource "aws_ssm_parameter" "datadog_api_key" {
   type        = "SecureString"
   value       = resource.datadog_api_key.api_key.key
 
-  tags = local.tags
+  tags = merge(local.tags, {
+    "copilot-application"="__all__"
+  })
 }
 
 resource "aws_ssm_parameter" "datadog_app_key" {
@@ -25,5 +27,7 @@ resource "aws_ssm_parameter" "datadog_app_key" {
   type        = "SecureString"
   value       = resource.datadog_application_key.app_key.key
 
-  tags = local.tags
+  tags = merge(local.tags, {
+    "copilot-application"="__all__"
+  })
 }


### PR DESCRIPTION

# Description

This enables Copilot to read the SSM params, which is required so that copilot can deploy a service with the datadog agent sidecar.


## Contributors

Let's acknowledge the people who contributed to the work.

## Type of change

- [ ] Refactoring (made code better without changing its behaviour)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How this has been tested

Please describe the tests that you ran to verify your changes.

If they are not automated tests please explain why and provide screenshots and/or instructions so they can reproduced.

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
